### PR TITLE
do not save dimension before frame is active. fixes #117

### DIFF
--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/MainJFrame.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/MainJFrame.java
@@ -41,6 +41,11 @@ public class MainJFrame extends JFrame
         @Override
         public void componentResized( ComponentEvent e )
         {
+            if ( !frame.isActive() )
+            { // awt.EDT fires off a couple of events before the frame is active
+              // the second changes the frame's size slightly. protect against this.
+                return;
+            }
             ConfigTools.setInt(
                 uiConfig, CFG_GAME_WINDOW_WIDTH,  frame.getWidth() );
 


### PR DESCRIPTION
reasonably principled fix.