### PR TITLE
grab keyboard focus after dialog goes so keystrokes are not lost. fix…

### DIFF
--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingGameLaunch.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingGameLaunch.java
@@ -92,6 +92,9 @@ public class SwingGameLaunch implements GameLaunch
     public void run( String[] args )
     {
         showIntroDialog();
+        // After the dialog has gone, return keyboard 
+        // focus so keystrokes are not lost.
+        frame.getRootPane().grabFocus();
         loop.run();
     }
 


### PR DESCRIPTION
…es #102 

Seems clear that after the dialog is done the focus should return to the parent. This code should not really be necessary.