### PR TITLE
Dont merge this!

### DIFF
--- a/rabbit-escape-engine/src/rabbitescape/engine/BehaviourTools.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/BehaviourTools.java
@@ -31,27 +31,17 @@ public class BehaviourTools
         return pickUpToken( type, false );
     }
 
-    public boolean rabbitIsFalling()
+    public boolean rabbitIsFallingToDeath()
     {
         return
-               State.RABBIT_FALLING == rabbit.state
-            || State.RABBIT_FALLING_1 == rabbit.state
-            || State.RABBIT_FALLING_1_TO_DEATH == rabbit.state
+               State.RABBIT_FALLING_1_TO_DEATH == rabbit.state
             || State.RABBIT_DYING_OF_FALLING_2 == rabbit.state
-            || State.RABBIT_DYING_OF_FALLING == rabbit.state
-            || State.RABBIT_FALLING_ONTO_LOWER_RIGHT == rabbit.state
-            || State.RABBIT_FALLING_ONTO_RISE_RIGHT == rabbit.state
-            || State.RABBIT_FALLING_ONTO_LOWER_LEFT == rabbit.state
-            || State.RABBIT_FALLING_ONTO_RISE_LEFT == rabbit.state
-            || State.RABBIT_FALLING_1_ONTO_LOWER_RIGHT == rabbit.state
-            || State.RABBIT_FALLING_1_ONTO_RISE_RIGHT == rabbit.state
-            || State.RABBIT_FALLING_1_ONTO_LOWER_LEFT == rabbit.state
-            || State.RABBIT_FALLING_1_ONTO_RISE_LEFT == rabbit.state ;
+            || State.RABBIT_DYING_OF_FALLING == rabbit.state ;
     }
     
     public boolean pickUpToken( Token.Type type, boolean evenIfNotOnGround )
     {
-        if ( rabbitIsFalling() && rabbit.isFallingToDeath() )
+        if ( rabbitIsFallingToDeath() )
         {
             return false; // Dying rabbits not allowed to consume tokens
         }

--- a/rabbit-escape-engine/src/rabbitescape/engine/BehaviourTools.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/BehaviourTools.java
@@ -31,8 +31,31 @@ public class BehaviourTools
         return pickUpToken( type, false );
     }
 
+    public boolean rabbitIsFalling()
+    {
+        return
+               State.RABBIT_FALLING == rabbit.state
+            || State.RABBIT_FALLING_1 == rabbit.state
+            || State.RABBIT_FALLING_1_TO_DEATH == rabbit.state
+            || State.RABBIT_DYING_OF_FALLING_2 == rabbit.state
+            || State.RABBIT_DYING_OF_FALLING == rabbit.state
+            || State.RABBIT_FALLING_ONTO_LOWER_RIGHT == rabbit.state
+            || State.RABBIT_FALLING_ONTO_RISE_RIGHT == rabbit.state
+            || State.RABBIT_FALLING_ONTO_LOWER_LEFT == rabbit.state
+            || State.RABBIT_FALLING_ONTO_RISE_LEFT == rabbit.state
+            || State.RABBIT_FALLING_1_ONTO_LOWER_RIGHT == rabbit.state
+            || State.RABBIT_FALLING_1_ONTO_RISE_RIGHT == rabbit.state
+            || State.RABBIT_FALLING_1_ONTO_LOWER_LEFT == rabbit.state
+            || State.RABBIT_FALLING_1_ONTO_RISE_LEFT == rabbit.state ;
+    }
+    
     public boolean pickUpToken( Token.Type type, boolean evenIfNotOnGround )
     {
+        if ( rabbitIsFalling() && rabbit.isFallingToDeath() )
+        {
+            return false; // Dying rabbits not allowed to consume tokens
+        }
+
         if ( evenIfNotOnGround || onGround() )
         {
             Token token = world.getTokenAt( rabbit.x, rabbit.y );

--- a/rabbit-escape-engine/src/rabbitescape/engine/Rabbit.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/Rabbit.java
@@ -14,6 +14,8 @@ public class Rabbit extends Thing
 {
     private final List<Behaviour> behaviours;
     private final List<Behaviour> behavioursTriggerOrder;
+    
+    private Falling falling;
 
     public Direction dir;
     public boolean onSlope;
@@ -35,7 +37,7 @@ public class Rabbit extends Thing
         Exploding exploding = new Exploding();
         OutOfBounds outOfBounds = new OutOfBounds();
         Exiting exiting = new Exiting();
-        Falling falling = new Falling( climbing );
+        falling = new Falling( climbing );
         Bashing bashing = new Bashing();
         Bridging bridging = new Bridging();
         Blocking blocking = new Blocking();
@@ -64,6 +66,11 @@ public class Rabbit extends Thing
         behaviours.add( walking );
 
         assert behavioursTriggerOrder.size() == behaviours.size();
+    }
+
+    public boolean isFallingToDeath()
+    {
+        return falling.isFallingToDeath();
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Falling.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Falling.java
@@ -20,6 +20,11 @@ public class Falling extends Behaviour
     {
         this.climbing = climbing;
     }
+    
+    public boolean isFallingToDeath()
+    {
+        return heightFallen > fatalHeight ;
+    }
 
     @Override
     public void cancel()

--- a/rabbit-escape-engine/test/rabbitescape/engine/logic/TestTokens.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/logic/TestTokens.java
@@ -262,4 +262,76 @@ public class TestTokens
             "#D#"
         );
     }
+    
+    @Test
+    public void Rabbits_falling_to_death_do_not_consume_tokens()
+    {
+        World world = createWorld(
+            " r       ",
+            "  j      ",
+            "   r     ",
+            "    j    ",
+            "     r   ",
+            "      j  ",
+            "       r ",
+            "         ",
+            "         ",
+            "         ",
+            "         ",
+            "#bdikcp*#",
+            "####)(*/#",
+            "#########",
+            ":*=db",
+            ":*=\\"
+        );
+
+        assertWorldEvolvesLike( 
+            world,
+            8,
+            new String[] {
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "         ",
+                "#bdi    #",
+                "####****#",
+                "#########",
+                ":*=)k",
+                ":*=(c",
+                ":*=\\p",
+                ":*=/db"
+            });
+    }
+    
+    @Test
+    public void Rabbits_falling_and_living_do_consume_tokens()
+    {
+        World world = createWorld(
+            " r       ",
+            "   r   r ",
+            "     r   ",
+            "#bpbpcpdp",
+            "####)(\\/#",
+            "#########"
+        );
+
+        assertWorldEvolvesLike( 
+            world,
+            8,
+            new String[] {
+                "         ",
+                "         ",
+                "         ",
+                "#       p",
+                "####)(\\ #",
+                "####### #"
+            });
+    }
 }


### PR DESCRIPTION
I just did a pull request so you can see easily what happens if this is done wrong.

In the test case the rabbits are falling different heights. A rabbit falling an even number of squares splats and consumes a token.
```
    [junit] Testcase: Rabbits_falling_to_death_do_not_consume_tokens took 0.022 sec
    [junit] 	FAILED
    [junit] 
    [junit] Expected:     ["         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "#bdi    #", "####****#", "#########", ":*=)k", ":*=(c", ":*=\p", ":*=/db"]
    [junit]      but: was ["         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "#b i    #", "####*(**#", "#########", ":*=)k", ":*=\p", ":*=/b"]
    [junit] junit.framework.AssertionFailedError: 
    [junit] Expected:     ["         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "#bdi    #", "####****#", "#########", ":*=)k", ":*=(c", ":*=\p", ":*=/db"]
    [junit]      but: was ["         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "         ", "#b i    #", "####*(**#", "#########", ":*=)k", ":*=\p", ":*=/b"]
    [junit] 	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
    [junit] 	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
    [junit] 	at rabbitescape.engine.util.WorldAssertions.assertWorldEvolvesLike(WorldAssertions.java:148)
    [junit] 	at rabbitescape.engine.logic.TestTokens.Rabbits_falling_to_death_do_not_consume_tokens(TestTokens.java:288)

```