### PR TITLE
Text ui: falling out of bounds 

### DIFF
--- a/rabbit-escape-engine/src/rabbitescape/engine/textworld/RabbitRenderer.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/textworld/RabbitRenderer.java
@@ -4,6 +4,7 @@ import static rabbitescape.engine.Direction.*;
 
 import java.util.List;
 
+import rabbitescape.engine.ChangeDescription.State;
 import rabbitescape.engine.Rabbit;
 
 public class RabbitRenderer
@@ -12,6 +13,10 @@ public class RabbitRenderer
     {
         for ( Rabbit rabbit : rabbits )
         {
+            if ( State.RABBIT_OUT_OF_BOUNDS == rabbit.state )
+            {
+                continue;
+            }
             chars.set(
                 rabbit.x,
                 rabbit.y,

--- a/rabbit-escape-ui-text/src/rabbitescape/ui/text/TextGameLaunch.java
+++ b/rabbit-escape-ui-text/src/rabbitescape/ui/text/TextGameLaunch.java
@@ -53,7 +53,7 @@ public class TextGameLaunch implements GameLaunch
                     Thread.sleep( 200 );
                 }
 
-                printWorld();
+                printWorld(inputHandler);
 
                 if ( useInput )
                 {
@@ -75,20 +75,23 @@ public class TextGameLaunch implements GameLaunch
 
             checkWon();
         }
-        printSolution( inputHandler.solution() );
+        printSolution( inputHandler.solution(), true );
     }
 
-    private void printSolution( String solution )
+    private void printSolution( String solution, boolean withObfuscation )
     {
         terminal.out.println(
             t( ":solution.1=${solution}", newMap( "solution", solution ) ) );
 
-        terminal.out.println(
-            t(
-                ":solution.1.code=${solution}",
-                newMap( "solution", MegaCoder.encode( solution ) )
-            )
-        );
+        if ( withObfuscation )
+        {
+            terminal.out.println(
+                t(
+                    ":solution.1.code=${solution}",
+                    newMap( "solution", MegaCoder.encode( solution ) )
+                )
+            );
+        }
     }
 
     private void checkWon()
@@ -99,8 +102,9 @@ public class TextGameLaunch implements GameLaunch
         }
     }
 
-    private void printWorld()
+    private void printWorld( InputHandler inputHandler )
     {
+        printSolution( inputHandler.solution(), false );
         printWorldImpl( false );
         printState();
     }


### PR DESCRIPTION
bonus: print solution so far during text mode games. Often the player wants to put a token next to the previous token. instead of squinting and trying to read the column numbers, can calculate relative coordinates.

fixes 149
only thing I am not sure about here: as well as skipping the set() call I am skipping the rabbit.saveState() call. I don't know what that does, and it sounds like a strange thing to be in the rabbit position drawing call.

OutOfBounds does not implement saveState, so I guess its OK.

Tests are passed, and I played a few levels in text ui and all seems well.