### PR TITLE
Text input

### DIFF
--- a/rabbit-escape-engine/src/rabbitescape/engine/textworld/InputExpansion.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/textworld/InputExpansion.java
@@ -1,0 +1,29 @@
+package rabbitescape.engine.textworld;
+
+public class InputExpansion
+{
+
+    public final String character, expansion;
+    
+    public final static InputExpansion[] expansions = new InputExpansion[] {
+        new InputExpansion( "b", "bash" ),
+        new InputExpansion( "d", "dig" ),
+        new InputExpansion( "i", "bridge" ),
+        new InputExpansion( "k", "block" ),
+        new InputExpansion( "c", "climb" ),
+        new InputExpansion( "p", "explode" )
+    };
+    
+    public InputExpansion( String character, String expansion )
+    {
+        this.character = character;
+        this.expansion = expansion;
+    }
+    
+    @Override
+    public String toString()
+    {
+        return character + ": " + expansion ;
+    }
+
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/util/Util.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/util/Util.java
@@ -781,4 +781,28 @@ public class Util
             }
         };
     }
+    
+    /**
+     * @brief Replace all matches, but preserves the first capturing group.
+     *        Compare to String.replaceAll, which replaces the whole match.
+     * @param patternFlags The flags from java.util.regex.Pattern.
+     */
+    public static String regexReplacePreserveGroup( String s, String regex, int patternFlags )
+    {
+        Pattern p = Pattern.compile( regex, patternFlags );
+        Matcher dsMatcher = p.matcher( s );
+        StringBuffer sb = new StringBuffer();
+        while ( dsMatcher.find() )
+        {
+            dsMatcher.appendReplacement( sb, "$1" );
+        }
+        dsMatcher.appendTail( sb );
+
+        return sb.toString();
+    }
+
+    public static String regexReplacePreserveGroup( String s, String regex )
+    {
+        return regexReplacePreserveGroup( s, regex, 0 );
+    }
 }

--- a/rabbit-escape-engine/src/rabbitescape/engine/util/Util.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/util/Util.java
@@ -787,7 +787,7 @@ public class Util
      *        Compare to String.replaceAll, which replaces the whole match.
      * @param patternFlags The flags from java.util.regex.Pattern.
      */
-    public static String regexReplacePreserveGroup( String s, String regex, int patternFlags )
+    public static String regexRemovePreserveGroup( String s, String regex, int patternFlags )
     {
         Pattern p = Pattern.compile( regex, patternFlags );
         Matcher dsMatcher = p.matcher( s );
@@ -801,8 +801,23 @@ public class Util
         return sb.toString();
     }
 
-    public static String regexReplacePreserveGroup( String s, String regex )
+    public static String regexRemovePreserveGroup( String s, String regex )
     {
-        return regexReplacePreserveGroup( s, regex, 0 );
+        return regexRemovePreserveGroup( s, regex, 0 );
     }
+    
+    public static String regexReplace( String s, String regex, String replacement )
+    {
+        Pattern p = Pattern.compile( regex );
+        Matcher dsMatcher = p.matcher( s );
+        StringBuffer sb = new StringBuffer();
+        while ( dsMatcher.find() )
+        {
+            dsMatcher.appendReplacement( sb, replacement );
+        }
+        dsMatcher.appendTail( sb );
+
+        return sb.toString();
+    }
+    
 }

--- a/rabbit-escape-engine/test/rabbitescape/engine/util/TestRegexUtil.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/util/TestRegexUtil.java
@@ -1,0 +1,39 @@
+package rabbitescape.engine.util;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import org.junit.Test;
+
+public class TestRegexUtil
+{
+
+    @Test
+    public void Regex_remove_preserve_group()
+    {
+        String before, regex, after;
+        
+        before = "Level: \\\"Tetris\\\"";
+        regex  = "\\\\(\")";
+        after  = "Level: \"Tetris\"";
+        assertThat(Util.regexRemovePreserveGroup( before , regex ), equalTo(after));
+        
+        before = "\\\"Thing in escaped quotes\\\" \"Thing in quotes\"";
+        regex  = "\\\\(\")";
+        after  = "\"Thing in escaped quotes\" \"Thing in quotes\"";
+        assertThat(Util.regexRemovePreserveGroup( before , regex ), equalTo(after));
+    }
+    
+    @Test
+    public void Regex_replace()
+    {
+        String before, regex, replacement, after;
+        
+        before = "The brown fox.";
+        regex  = "brown";
+        replacement = "red";
+        after  = "The red fox.";
+        assertThat(Util.regexReplace( before, regex, replacement ), equalTo(after));
+    }
+    
+}

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import rabbitescape.engine.util.Util;
+
 /**
  * @brief encapsulates what has been retrieved about a github issue
  */
@@ -300,7 +302,7 @@ public class GitHubIssue
         fixed = fixed.replaceAll( "^\n", "" );
 
         // Strip trailing spaces from meta lines
-        fixed = GitHubJsonTools.regexReplacePreserveGroup( fixed, "^(:.*?) *?$", Pattern.MULTILINE );
+        fixed = Util.regexReplacePreserveGroup( fixed, "^(:.*?) *?$", Pattern.MULTILINE );
         return fixed;
     }
 
@@ -323,12 +325,12 @@ public class GitHubIssue
         String s2;
         s2 = s1.replaceAll( "(\\\\r)", "" );
 
-        s2 = GitHubJsonTools.regexReplacePreserveGroup( s2, "\\\\(\\\")" );
+        s2 = Util.regexReplacePreserveGroup( s2, "\\\\(\\\")" );
 
         // Undouble slashes
         // I don't understand why this does not work without the capturing group
         // and back reference.
-        s2 = GitHubJsonTools.regexReplacePreserveGroup( s2, "(\\\\)\\\\" );
+        s2 = Util.regexReplacePreserveGroup( s2, "(\\\\)\\\\" );
 
         return s2;
     }

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/GitHubIssue.java
@@ -302,7 +302,7 @@ public class GitHubIssue
         fixed = fixed.replaceAll( "^\n", "" );
 
         // Strip trailing spaces from meta lines
-        fixed = Util.regexReplacePreserveGroup( fixed, "^(:.*?) *?$", Pattern.MULTILINE );
+        fixed = Util.regexRemovePreserveGroup( fixed, "^(:.*?) *?$", Pattern.MULTILINE );
         return fixed;
     }
 
@@ -325,12 +325,12 @@ public class GitHubIssue
         String s2;
         s2 = s1.replaceAll( "(\\\\r)", "" );
 
-        s2 = Util.regexReplacePreserveGroup( s2, "\\\\(\\\")" );
+        s2 = Util.regexRemovePreserveGroup( s2, "\\\\(\\\")" );
 
         // Undouble slashes
         // I don't understand why this does not work without the capturing group
         // and back reference.
-        s2 = Util.regexReplacePreserveGroup( s2, "(\\\\)\\\\" );
+        s2 = Util.regexRemovePreserveGroup( s2, "(\\\\)\\\\" );
 
         return s2;
     }

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/GitHubJsonTools.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/GitHubJsonTools.java
@@ -75,29 +75,4 @@ public class GitHubJsonTools
         return ret.toArray( values );
     }
 
-    /**
-     * @brief Replace all matches, but preserves the first capturing group.
-     *        Compare to String.replaceAll, which replaces the whole match. This
-     *        is in the JSON class because JSON String vales have escaped
-     *        characters to be cleaned up.
-     * @param patternFlags The flags from java.util.regex.Pattern.
-     */
-    public static String regexReplacePreserveGroup( String s, String regex, int patternFlags )
-    {
-        Pattern p = Pattern.compile( regex, patternFlags );
-        Matcher dsMatcher = p.matcher( s );
-        StringBuffer sb = new StringBuffer();
-        while ( dsMatcher.find() )
-        {
-            dsMatcher.appendReplacement( sb, "$1" );
-        }
-        dsMatcher.appendTail( sb );
-
-        return sb.toString();
-    }
-
-    public static String regexReplacePreserveGroup( String s, String regex )
-    {
-        return regexReplacePreserveGroup( s, regex, 0 );
-    }
 }

--- a/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputExpansion.java
+++ b/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputExpansion.java
@@ -1,4 +1,4 @@
-package rabbitescape.engine.textworld;
+package rabbitescape.ui.text;
 
 public class InputExpansion
 {

--- a/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputHandler.java
+++ b/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputHandler.java
@@ -16,7 +16,6 @@ import rabbitescape.engine.solution.SolutionRunner;
 import rabbitescape.engine.solution.UntilAction;
 import rabbitescape.engine.solution.WaitAction;
 import rabbitescape.engine.solution.SolutionCommand;
-import rabbitescape.engine.textworld.InputExpansion;
 import rabbitescape.engine.util.Util;
 
 public class InputHandler
@@ -91,7 +90,7 @@ public class InputHandler
     /**
      * Note: changes the argument.
      */
-    private String expandAbbreviations( String input )
+    static String expandAbbreviations( String input )
     {
         if ( input.equals( "" ) )
         {

--- a/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputHandler.java
+++ b/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputHandler.java
@@ -16,6 +16,7 @@ import rabbitescape.engine.solution.SolutionRunner;
 import rabbitescape.engine.solution.UntilAction;
 import rabbitescape.engine.solution.WaitAction;
 import rabbitescape.engine.solution.SolutionCommand;
+import rabbitescape.engine.util.Util;
 
 public class InputHandler
 {
@@ -86,13 +87,18 @@ public class InputHandler
         return true;
     }
 
+    /**
+     * Note: changes the argument.
+     */
     private String expandAbbreviations( String input )
     {
         if ( input.equals( "" ) )
         {
             return "1";
         }
-        return null;
+        // Surround coordinates with brackets
+        input = Util.regexReplace( input, "\\(?+([0-9]+,[0-9]+)\\)?+", "($1)" );
+        return input;
     }
 
     private void append( SolutionCommand newStep )

--- a/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputHandler.java
+++ b/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputHandler.java
@@ -16,6 +16,7 @@ import rabbitescape.engine.solution.SolutionRunner;
 import rabbitescape.engine.solution.UntilAction;
 import rabbitescape.engine.solution.WaitAction;
 import rabbitescape.engine.solution.SolutionCommand;
+import rabbitescape.engine.textworld.InputExpansion;
 import rabbitescape.engine.util.Util;
 
 public class InputHandler
@@ -23,7 +24,7 @@ public class InputHandler
     private final SandboxGame sandboxGame;
     private final Terminal terminal;
     private final List<SolutionCommand> solution;
-
+    
     public InputHandler( SandboxGame sandboxGame, Terminal terminal )
     {
         this.sandboxGame = sandboxGame;
@@ -98,8 +99,18 @@ public class InputHandler
         }
         // Surround coordinates with brackets
         input = Util.regexReplace( input, "\\(?+([0-9]+,[0-9]+)\\)?+", "($1)" );
+        // Expand token selection shortcuts
+        for ( InputExpansion e : InputExpansion.expansions )
+        {
+            input = Util.regexReplace( 
+                input, 
+                "\\b" + e.character + "\\b", 
+                e.expansion
+            );
+        }
         return input;
     }
+
 
     private void append( SolutionCommand newStep )
     {
@@ -149,14 +160,23 @@ public class InputHandler
 
     private boolean help()
     {
-        terminal.out.println( t(
+        String msg = 
             "\n" +
             "Press return to move forward a time step.\n" +
             "Type 'exit' to stop.\n" +
             "Type an ability name (e.g. 'bash') to switch to that ability.\n" +
             "Type '(x,y)' (e.g '(2,3)') to place a token.\n" +
-            "Type a number (e.g. '5') to skip that many steps.\n"
-        ) );
+            "Type a number (e.g. '5') to skip that many steps.\n" +
+            "\n" +
+            "The following abbreviations are available:\n" ;
+        for ( InputExpansion e : InputExpansion.expansions )
+        {
+            msg = msg + e + "\n";
+        }
+        msg = msg + 
+            "Brackets may be omitted when placing tokens: '2,3'.\n";
+                
+        terminal.out.println( t( msg ) );
 
         return false;
     }

--- a/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputHandler.java
+++ b/rabbit-escape-ui-text/src/rabbitescape/ui/text/InputHandler.java
@@ -34,11 +34,9 @@ public class InputHandler
     {
         String input = input();
 
-        if ( input.equals( "" ) )
-        {
-            input = "1";
-        }
-        else if ( input.equals( "help" ) )
+        input = expandAbbreviations( input );
+        
+        if ( input.equals( "help" ) )
         {
             return help();
         }
@@ -86,6 +84,15 @@ public class InputHandler
         }
 
         return true;
+    }
+
+    private String expandAbbreviations( String input )
+    {
+        if ( input.equals( "" ) )
+        {
+            return "1";
+        }
+        return null;
     }
 
     private void append( SolutionCommand newStep )

--- a/rabbit-escape-ui-text/test/rabbitescape/ui/text/TestInputHandler.java
+++ b/rabbit-escape-ui-text/test/rabbitescape/ui/text/TestInputHandler.java
@@ -11,11 +11,21 @@ public class TestInputHandler
     public void Expand_abbreviations()
     {
         String abbrev, expected, expanded;
+
         abbrev = "";
         expected = "1" ;
         expanded = InputHandler.expandAbbreviations( abbrev );
         assertThat( expanded, equalTo( expected ) );
         
+        abbrev = "i;b;d;k;1,2;c;p";
+        expected = "bridge;bash;dig;block;(1,2);climb;explode" ;
+        expanded = InputHandler.expandAbbreviations( abbrev );
+        assertThat( expanded, equalTo( expected ) );
+        
+        abbrev = "in;bridge;di;ok;(1,2)";
+        expected = "in;bridge;di;ok;(1,2)" ;
+        expanded = InputHandler.expandAbbreviations( abbrev );
+        assertThat( expanded, equalTo( expected ) );
     }
     
 }

--- a/rabbit-escape-ui-text/test/rabbitescape/ui/text/TestInputHandler.java
+++ b/rabbit-escape-ui-text/test/rabbitescape/ui/text/TestInputHandler.java
@@ -1,0 +1,21 @@
+package rabbitescape.ui.text;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import org.junit.Test;
+
+public class TestInputHandler
+{
+    @Test
+    public void Expand_abbreviations()
+    {
+        String abbrev, expected, expanded;
+        abbrev = "";
+        expected = "1" ;
+        expanded = InputHandler.expandAbbreviations( abbrev );
+        assertThat( expanded, equalTo( expected ) );
+        
+    }
+    
+}


### PR DESCRIPTION
- token shortcuts (eg d for dig)
- can omit brackets for coordinates

i tried to do this in a way that would not hamper & use or future expansion to allow multiple actions to be entered at once, separated by ';'.