### PR TITLE
Text ui: out of bounds bridge building

### DIFF
--- a/rabbit-escape-engine/src/rabbitescape/engine/Block.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/Block.java
@@ -17,13 +17,34 @@ public class Block
     public final int y;
     public final Type type;
     public final int variant;
+    public final boolean outOfBounds;
 
+    /**
+     * Blocks that are added later (bridges built by rabbits, for example) 
+     * may be tested for bounds as they are added.
+     */
+    public Block( int x, int y, Type type, int variant, World w )
+    {
+        this.x = x;
+        this.y = y;
+        this.type = type;
+        this.variant = variant;
+        this.outOfBounds =    x <  0 
+                           || y <  0
+                           || x >= w.size.width
+                           || y >= w.size.height ;
+    }
+
+    /**
+     * Blocks may be created before the world. Bounds checking is done elsewhere
+     */
     public Block( int x, int y, Type type, int variant )
     {
         this.x = x;
         this.y = y;
         this.type = type;
         this.variant = variant;
+        this.outOfBounds = false ;
     }
 
     public Direction riseDir()

--- a/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Bridging.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Bridging.java
@@ -444,7 +444,8 @@ public class Bridging extends Behaviour
                         rabbit.x,
                         rabbit.y,
                         Block.Type.bridge_up_right,
-                        0
+                        0,
+                        world
                     )
                 );
 
@@ -459,7 +460,8 @@ public class Bridging extends Behaviour
                         rabbit.x,
                         rabbit.y,
                         Block.Type.bridge_up_left,
-                        0
+                        0,
+                        world
                     )
                 );
 
@@ -474,7 +476,8 @@ public class Bridging extends Behaviour
                         rabbit.x,
                         rabbit.y,
                         Block.Type.bridge_up_right,
-                        0
+                        0,
+                        world
                     )
                 );
 
@@ -489,7 +492,8 @@ public class Bridging extends Behaviour
                         rabbit.x,
                         rabbit.y,
                         Block.Type.bridge_up_left,
-                        0
+                        0,
+                        world
                     )
                 );
 
@@ -503,7 +507,8 @@ public class Bridging extends Behaviour
                         rabbit.x,
                         rabbit.y,
                         Block.Type.bridge_up_right,
-                        0
+                        0,
+                        world
                     )
                 );
                 return true;
@@ -516,7 +521,8 @@ public class Bridging extends Behaviour
                         rabbit.x,
                         rabbit.y,
                         Block.Type.bridge_up_left,
-                        0
+                        0,
+                        world
                     )
                 );
                 return true;
@@ -530,7 +536,8 @@ public class Bridging extends Behaviour
                         rabbit.x,
                         rabbit.y,
                         Block.Type.bridge_up_right,
-                        0
+                        0,
+                        world
                     )
                 );
                 return true;
@@ -544,7 +551,8 @@ public class Bridging extends Behaviour
                         rabbit.x,
                         rabbit.y,
                         Block.Type.bridge_up_left,
-                        0
+                        0,
+                        world
                     )
                 );
                 return true;

--- a/rabbit-escape-engine/src/rabbitescape/engine/textworld/BlockRenderer.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/textworld/BlockRenderer.java
@@ -10,6 +10,10 @@ public class BlockRenderer
     {
         for ( Block block : blocks )
         {
+            if ( block.outOfBounds )
+            {
+                continue;
+            }
             chars.set( block.x, block.y, charForBlock( block ) );
         }
     }

--- a/rabbit-escape-engine/test/rabbitescape/engine/logic/TestBridging.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/logic/TestBridging.java
@@ -1,5 +1,6 @@
 package rabbitescape.engine.logic;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.*;
 import static rabbitescape.engine.textworld.TextWorldManip.*;
 import static rabbitescape.engine.util.WorldAssertions.*;
@@ -1555,5 +1556,45 @@ public class TestBridging
                 "####"
             )
         );
+    }
+    
+    @Test
+    public void Bridge_out_of_bounds()
+    {
+        World world = createWorld(
+            "       *",
+            "*     ##",
+            "###  ###",
+            "        ",
+            "ij    ri",
+            "###  ###",
+            "        ",
+            "        ",
+            " ij  ri ",
+            "###  ###",
+            ":*=ij",
+            ":*=ir"
+        );
+
+        // The test will find out of 
+        // bounds exceptions from rendering
+        // bridges outside the world.
+        assertWorldEvolvesLike(
+            world,
+            10,
+            new String[] {
+                "  (   ) ",
+                " (    ##",
+                "###  ###",
+                "        ",
+                "        ",
+                "###  ###",
+                "        ",
+                "        ",
+                ")      (",
+                "###  ###",
+            });
+
+        assertThat( world.num_killed, equalTo ( 6 ) );
     }
 }


### PR DESCRIPTION
- Did not seem right to stop the engine from allowing OOB bridges, because they are used in swing.
- Seemed bad to check bounds for each block as it is drawn, as that sounds like a performance problem

So I added the boolean to the Block class, which is used by the text ui renderer to avoid trying to draw OOB bridges.