### PR TITLE
Tests without Ant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,9 +260,14 @@ runlevel: compile
 runat: compile
 	java -cp $(CLASSPATH) rabbitescape.ui.swing.AnimationTester
 
+JAVA_DIRS = rabbit-escape-engine rabbit-escape-render rabbit-escape-ui-text rabbit-escape-ui-swing
+TEST_FILES = $(shell find ${JAVA_DIRS} -name "Test*.java")
+TEST_CLASSES = $(shell echo ${TEST_FILES} | sed 's/[-a-z]*\/[a-z]*\/\([^ ]*\)\.java/\1/g' | sed 's/\//./g') 
+
 test: compile
 	# Work around what looks like an Ant 1.9 bug by including the classpath here
-	CLASSPATH=lib/org.hamcrest.core_1.3.0.jar:lib/junit.jar ant test
+	java -cp ${CLASSPATH}:lib/org.hamcrest.core_1.3.0.jar:lib/junit.jar org.junit.runner.JUnitCore ${TEST_CLASSES}
+
 
 slowtest: test
 	./slowtest/hard-1.expect | grep 'You won!'

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,6 @@ TEST_FILES = $(shell find ${JAVA_DIRS} -name "Test*.java")
 TEST_CLASSES = $(shell echo ${TEST_FILES} | sed 's/[-a-z]*\/[a-z]*\/\([^ ]*\)\.java/\1/g' | sed 's/\//./g') 
 
 test: compile
-	# Work around what looks like an Ant 1.9 bug by including the classpath here
 	java -cp ${CLASSPATH}:lib/org.hamcrest.core_1.3.0.jar:lib/junit.jar org.junit.runner.JUnitCore ${TEST_CLASSES}
 
 


### PR DESCRIPTION
This one seems pretty clear cut.  The change is quite simple, and the performance gain is decent.

Current code with Ant:

```
$ time make test
9.0s
```

Without Ant (this pull request):

```
$ time make test
6.2s
```

It's less code, with just one nasty line of sed, that can probably be simplified and/or replaced with Makefile magic.
