### PR TITLE
Remove text arg from ./runrabbit (now it's the default)

### DIFF
--- a/rabbit-escape-ui-text/src/rabbitescape/ui/text/TextMain.java
+++ b/rabbit-escape-ui-text/src/rabbitescape/ui/text/TextMain.java
@@ -62,7 +62,7 @@ public class TextMain
             }
             if ( level.isPresent() )
             {
-                TextSingleGameEntryPoint.entryPoint( args );
+                TextSingleGameEntryPoint.entryPoint( new String[] {level.getValue()} );
                 System.exit( 0 );
             }
             if ( encode.isPresent() )
@@ -136,23 +136,22 @@ public class TextMain
     {
         //                                                          Eighty character limit >|
         System.out.println( t(
+            "runrabbit [options]\n" +
+            "If no options are given, the game starts the text UI with menus.\n" +
             "Any option can be abbreviated: '--help' becomes '-h'.\n" +
-            "runrabbit --help                        (This) message and exit.\n" +
-            "runrabbit                               Play using the swing GUI menus.\n" +
-            "runrabbit swing                         Play using the swing GUI menus.\n" +
-            "runrabbit swing level.rel               Play a single level using the swing GUI.\n" +
-            "runrabbit text                          Play using the text UI.\n" +
-            "runrabbit text level.rel                Play a single level using the text UI.\n" +
-            "runrabbit text --level level.rel        Play a single level using the text UI.\n" +
-            "runrabbit text --noinput level.rel      Level plays out with no token drops.\n" +
-            "runrabbit text --level <file> --solution <n>   Print world steps.\n" +
-            "runrabbit text --encode <string>        Obfuscate a string, for hints etc\n" +
-            "runrabbit text --decode <string>        Deobfuscate.\n" +
-            "runrabbit text --encode <level.rel>     Obfuscate hints and solutions.\n" +
-            "runrabbit text --decode <level.code.rel>   Deobfuscate.\n" +
-            "runrabbit text --placeholders <level.rel>  Rewrite file, inserting blank meta\n" +
-            "                                           and re-ordering meta. Decodes.\n" +
-            "runrabbit text --template <level.rel>   Create blank rel file\n\n" +
+            " --help                         (This) message and exit.\n" +
+            " swing                          Play using the swing GUI menus.\n" +
+            " swing level.rel                Play a single level using the swing GUI.\n" +
+            " [--level] level.rel            Play a single level using the text UI.\n" +
+            " --level <file> --solution <n>  Print world steps.\n" +
+            " --encode <string>              Obfuscate a string, for hints etc\n" +
+            " --decode <string>              Deobfuscate.\n" +
+            " --encode <level.rel>           Obfuscate hints and solutions.\n" +
+            " --decode <level.code.rel>      Deobfuscate.\n" +
+            " --placeholders <level.rel>     Rewrite file, inserting blank meta\n" +
+            "                                and re-ordering meta. Decodes.\n" +
+            " --template <level.rel>         Create blank rel file\n" +
+            "\n" +
             "When used with rel files the de/encode options will leave the source file\n" +
             "untouched, but may overwrite another file without further warning\n" +
             " foo.rel -> foo.code.rel          foo.code.rel -> foo.uncode.rel\n" +

--- a/runrabbit
+++ b/runrabbit
@@ -1,19 +1,10 @@
 #!/bin/bash
 CP=rabbit-escape-engine/bin/:rabbit-escape-render/bin/:rabbit-escape-ui-text/bin/:rabbit-escape-ui-swing/bin/
-if [ "$1" == "swing" ] || [ "$1" == "" ] # swing is the defualt
+if [ "$1" == "swing" ]
     then
     # shift drops the first arg, "swing". $@ passes the rest on.
     shift
     java -cp $CP rabbitescape.ui.swing.SwingMain "$@"
-elif [ "$1" == "text" ]
-    then
-    shift
-    java -cp $CP rabbitescape.ui.text.TextMain "$@"
-elif [ "$1" == "--help" ] || [ "$1" == "-h" ]
-    then
-    java -cp $CP rabbitescape.ui.text.TextMain "$@"
 else
-    echo "Option not recognised. You may find"
-    echo "./runrabbit --help"
-    echo "useful."
+    java -cp $CP rabbitescape.ui.text.TextMain "$@"
 fi

--- a/runrabbit.bat
+++ b/runrabbit.bat
@@ -2,18 +2,10 @@
 :: Find jar. Leave only one in the same directory
 for %%a in (*.jar) do set jar=%%a
 echo %jar%
-if  "%1" == "" (
-    java -cp %jar% rabbitescape.ui.swing.SwingMain
-	goto:eof
-)
 if  "%1" == "swing" (
     :: Kludgey, but using shift does not get rid of "swing" if it is the only arg
     java -cp %jar% rabbitescape.ui.swing.SwingMain %2 %3 %4 %5 %6 %7 %8 %9
 	goto:eof
 )
-if "%1" == "text" (
-    java -cp %jar% rabbitescape.ui.text.TextMain %2 %3 %4 %5 %6 %7 %8 %9
-	goto:eof
-)
-:: Default to help message
-java -cp %jar% rabbitescape.ui.text.TextMain -h
+:: Default to text ui and utils with all args
+java -cp %jar% rabbitescape.ui.text.TextMain %*

--- a/slowtests/runrabbit--level.expect
+++ b/slowtests/runrabbit--level.expect
@@ -1,0 +1,18 @@
+# see slowtests file
+
+set timeout 2
+
+spawn ./runrabbit --level ./rabbit-escape-engine/src/rabbitescape/levels/easy/level_01.rel
+
+# Play a solution move by move
+
+send "dig\r"
+send "(7,2)\r"
+send "15\r"
+
+# Exit by choosing "back" each time
+
+demand "You won!"
+
+# java exits and closes stream
+demand eof

--- a/slowtests/runrabbit--level.expect
+++ b/slowtests/runrabbit--level.expect
@@ -4,13 +4,13 @@ set timeout 2
 
 spawn ./runrabbit --level ./rabbit-escape-engine/src/rabbitescape/levels/easy/level_01.rel
 
+# No menu navigation: a single level was chosen in the command line options
+
 # Play a solution move by move
 
 send "dig\r"
 send "(7,2)\r"
 send "15\r"
-
-# Exit by choosing "back" each time
 
 demand "You won!"
 

--- a/slowtests/runrabbit-h.expect
+++ b/slowtests/runrabbit-h.expect
@@ -1,0 +1,10 @@
+# see slowtests file
+
+set timeout 2
+
+spawn ./runrabbit -h
+
+demand " --help                         (This) message and exit."
+
+# java exits and closes stream
+demand eof

--- a/slowtests/runrabbit-l--solution.expect
+++ b/slowtests/runrabbit-l--solution.expect
@@ -1,0 +1,10 @@
+# see slowtests file
+
+set timeout 2
+
+spawn ./runrabbit -l ./rabbit-escape-engine/src/rabbitescape/levels/easy/level_02.rel --solution=1
+
+demand "  Saved:3"
+
+# java exits and closes stream
+demand eof


### PR DESCRIPTION
and some expect tests.

I have not done expect tests for things that produce or change files ("--encode foo.rel" etc. I could not decide how best to tidy up the temp files that result, or where to put them while the test runs)

I still need to change the .bat

Comments so far gratefully received.