### PR TITLE
batch file checks ./dist too for jar. also only matches rabbit-escape…

### DIFF
--- a/runrabbit.bat
+++ b/runrabbit.bat
@@ -1,7 +1,30 @@
 @echo off
-:: Find jar. Leave only one in the same directory
-for %%a in (*.jar) do set jar=%%a
-echo %jar%
+
+setlocal
+setlocal enableextensions
+
+set jar=
+
+:: Find jar.
+
+for /F "usebackq" %%a in (`dir *.jar /b ^| findstr rabbit-escape-[0-9\.]*jar`) do set jar=%%a 2>nul
+
+echo Looking for jar in current dir: %jar%
+
+if not "%jar%" == "" goto start
+	
+cd dist
+for /F "usebackq" %%a in (`dir *.jar /b ^| findstr rabbit-escape-[0-9\.]*jar`) do set jar=.\dist\%%a
+echo Looking for jar in .\dist: %jar%
+cd ..
+
+if not "%jar%" == "" goto start
+
+echo Cannot find rabbit-escape-<version>.jar. Exit.
+goto:eof
+
+:start
+
 if  "%1" == "swing" (
     :: Kludgey, but using shift does not get rid of "swing" if it is the only arg
     java -cp %jar% rabbitescape.ui.swing.SwingMain %2 %3 %4 %5 %6 %7 %8 %9


### PR DESCRIPTION
…-<version>.jar not generic

couple of improvements for the batch file.

I now have my working copy of the repo in a directory shared between linux guest and host. i can run the bat in place after 'make dist-swing'. also still works if the jar is copied next to the bat.

batch files are horrible.