### PR TITLE
@Override in GitHubIssueDialog

### DIFF
--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/GitHubIssueDialog.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/GitHubIssueDialog.java
@@ -65,6 +65,7 @@ public class GitHubIssueDialog extends JDialog implements ChangeListener
         /**
          * @brief
          */
+        @Override
         public void notifyAndFetch( String url,
             String requestProperty,
             String notification,
@@ -381,6 +382,7 @@ public class GitHubIssueDialog extends JDialog implements ChangeListener
 
         levelFilterButton.addActionListener( new ActionListener()
         {
+            @Override
             public void actionPerformed( ActionEvent e )
             {
                 issueModel.setFilter( Label.LEVEL );
@@ -388,6 +390,7 @@ public class GitHubIssueDialog extends JDialog implements ChangeListener
         } );
         bugFilterButton.addActionListener( new ActionListener()
         {
+            @Override
             public void actionPerformed( ActionEvent e )
             {
                 issueModel.setFilter( Label.BUG );
@@ -395,6 +398,7 @@ public class GitHubIssueDialog extends JDialog implements ChangeListener
         } );
         allFilterButton.addActionListener( new ActionListener()
         {
+            @Override
             public void actionPerformed( ActionEvent e )
             {
                 issueModel.setFilter( Label.ALL );
@@ -402,6 +406,7 @@ public class GitHubIssueDialog extends JDialog implements ChangeListener
         } );
         fetchFollowButton.addActionListener( new ActionListener()
         {
+            @Override
             public void actionPerformed( ActionEvent e )
             {
                 fetchFollowupComments();
@@ -409,6 +414,7 @@ public class GitHubIssueDialog extends JDialog implements ChangeListener
         } );
         okButton.addActionListener( new ActionListener()
         {
+            @Override
             public void actionPerformed( ActionEvent e )
             {
                 choseWorld = true;
@@ -417,6 +423,7 @@ public class GitHubIssueDialog extends JDialog implements ChangeListener
         } );
         cancelButton.addActionListener( new ActionListener()
         {
+            @Override
             public void actionPerformed( ActionEvent e )
             {
                 setVisible( false );
@@ -529,6 +536,7 @@ public class GitHubIssueDialog extends JDialog implements ChangeListener
             timer.start();
         }
 
+        @Override
         public void actionPerformed( ActionEvent event )
         {
             statusBox.setText( statusBox.getText() + "." );


### PR DESCRIPTION
Not sure why Eclipse was not warning me about this before.

BTW, it may be a bit fiddly to get 028b2ebc629478489b4ed00991b0175d959a9a21 working. This should work (assuming that you already have that commit and 'git status' says you have nothing to commit)
- ```rm -r rabbit-escape-ui-text/.settings``` and the same for engine, text and render.
- in eclipse RMB on each project/'settings'/'Properties'/'Java Compiler'/'Settings/Warnings'/'Enable project specific settings'/OK for each project
- close Eclipse
- ```git reset --hard``` to bring back the '.settings' that were rm'd.
- restart Eclipse and you should have the new, strict regime