### PR TITLE
Swing framedump for solution playback

### DIFF
--- a/rabbit-escape-render/src/rabbitescape/render/gameloop/GeneralPhysics.java
+++ b/rabbit-escape-render/src/rabbitescape/render/gameloop/GeneralPhysics.java
@@ -49,7 +49,7 @@ public class GeneralPhysics implements Physics
         }
     }
 
-    private static final long max_allowed_skips = 10;
+    private final long max_allowed_skips;
     public static final long simulation_time_step_ms = 70;
 
     public int frame;
@@ -69,7 +69,8 @@ public class GeneralPhysics implements Physics
               winListener,
               new SolutionIgnorer(),
               SolutionInterpreter.getNothingPlaying(),
-              null);
+              null,
+              false);
     }
 
 
@@ -77,7 +78,8 @@ public class GeneralPhysics implements Physics
                            LevelWinListener winListener,
                            SolutionRecorderTemplate solutionRecorder,
                            SolutionInterpreter solutionInterpreter,
-                           UiPlayback uiPlayback)
+                           UiPlayback uiPlayback,
+                           boolean noFrameSkipping)
     {
         this.frame = 0;
         this.world = world;
@@ -86,6 +88,7 @@ public class GeneralPhysics implements Physics
         this.statsListeners = new ArrayList<>();
         this.solutionInterpreter = solutionInterpreter;
         this.uiPlayback = uiPlayback;
+        this.max_allowed_skips = noFrameSkipping ? 1 : 10 ;
     }
 
     public void setSpeed( int speed )

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/AnimationTester.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/AnimationTester.java
@@ -10,7 +10,6 @@ import rabbitescape.render.*;
 import rabbitescape.render.Frame;
 import rabbitescape.render.Renderer;
 
-import javax.imageio.ImageIO;
 import javax.swing.*;
 
 import java.awt.*;
@@ -18,9 +17,6 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferStrategy;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
 import java.util.*;
 import java.util.List;
 
@@ -244,7 +240,7 @@ public class AnimationTester extends JFrame
                 runMode = Mode.FRAME_DUMP;
                 return;
             case KeyEvent.VK_F6:
-                framesToGif();
+                frameDumper.framesToGif();
                 return;
             case KeyEvent.VK_Q:
                 System.exit( 0 );
@@ -259,7 +255,7 @@ public class AnimationTester extends JFrame
 
     private Mode runMode = Mode.RUN;
     private FrameCounter firstFrameDumped = null;
-    private String recordingDir = null;
+    private FrameDumper frameDumper = null ;
     private boolean forwardStep = false;
     private boolean backwardStep = false;
     private boolean frameLogging = false;
@@ -427,22 +423,6 @@ public class AnimationTester extends JFrame
         }
     }
 
-    private void framesToGif()
-    {
-        String cmd = String.format( "convert -delay 10 -loop 0 %s*.png %sanimation.gif",
-                recordingDir, recordingDir );
-        try
-        {
-            Runtime.getRuntime().exec( cmd );
-            System.out.printf( "Wrote:  %sanimation.gif\n", recordingDir );
-        }
-        catch ( IOException e )
-        {
-            System.err.println( "convert from ImageMagick is required to make animated gifs" );
-            e.printStackTrace();
-        }
-    }
-
     private class FrameCounter
     {
         private int frameSetNum ;
@@ -602,27 +582,12 @@ public class AnimationTester extends JFrame
             }
             if ( null == firstFrameDumped )
             {
-                RealFileSystem fs = new RealFileSystem();
-
-                int dirCount = 0;
-                do
-                {
-                    recordingDir = String.format( ".%srecordings%s%04d%s",
-                             File.separator, File.separator, dirCount++, File.separator );
-                }
-                while ( fs.exists( recordingDir ) );
-
-                fs.mkdirs( recordingDir );
-                System.out.printf( "Dumping %sanim_test_frame_<set>_<frame>.png:", recordingDir );
+                frameDumper = new FrameDumper();
                 firstFrameDumped = new FrameCounter( counter );
             }
-            BufferedImage im = new BufferedImage( canvas.getWidth(), canvas.getHeight(),
-                BufferedImage.TYPE_INT_ARGB );
-            drawFrame.draw( (Graphics2D)im.getGraphics() );
-            String fileName = String.format("%sanim_test_frame_%02d_%02d.png",
-                recordingDir, counter.getFrameSetNum(), counter.getFrameNum() );
-            System.out.printf(" %02d_%02d", counter.getFrameSetNum(), counter.getFrameNum() );
-            ImageIO.write( im, "PNG", new File( fileName ) );
+            String frameID = String.format("%02d_%02d", counter.getFrameSetNum(), counter.getFrameNum() );
+            frameDumper.dump( canvas, drawFrame, frameID );
+
             counter.inc();
             return counter;
         }

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/FrameDumper.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/FrameDumper.java
@@ -1,0 +1,104 @@
+package rabbitescape.ui.swing;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import rabbitescape.engine.util.RealFileSystem;
+
+public class FrameDumper
+{
+    private static final String sep = File.separator;
+
+    public final String recordingDir;
+    public final boolean active;
+
+    private int frameI;
+
+    public FrameDumper()
+    {
+        this.active = true;
+        RealFileSystem fs = new RealFileSystem();
+
+        frameI = 0;
+
+        int dirCount = 0;
+        String recordingDirTmp;
+        do
+        {
+            recordingDirTmp = String.format( ".%srecordings%s%04d%s",
+                     sep, sep, dirCount++, sep );
+        }
+        while ( fs.exists( recordingDirTmp ) );
+
+        recordingDir = recordingDirTmp;
+
+        fs.mkdirs( recordingDir );
+        System.out.printf( "Dumping %sanim_test_frame_<set>_<frame>.png:", recordingDir );
+    }
+
+    private FrameDumper( boolean active )
+    {
+        this.active = active;
+        this.recordingDir = null;
+    }
+
+    public static FrameDumper createInactiveDumper()
+    {
+        return new FrameDumper( false );
+    }
+
+    public void dump( java.awt.Canvas canvas, BufferedDraw drawFrame )
+    {
+        if ( !active )
+        {
+            return;
+        }
+        dump( canvas, drawFrame, String.format( "%07d", frameI++ ) );
+    }
+
+    public void dump( java.awt.Canvas canvas, BufferedDraw drawFrame, String frameID )
+    {
+        if ( !active )
+        {
+            return;
+        }
+        BufferedImage im = new BufferedImage( canvas.getWidth(), canvas.getHeight(),
+            BufferedImage.TYPE_INT_ARGB );
+        drawFrame.draw( (Graphics2D)im.getGraphics() );
+        String fileName = String.format( "%sframe_%s.png", recordingDir, frameID );
+        System.out.printf( " " + frameID );
+        try
+        {
+            ImageIO.write( im, "PNG", new File( fileName ) );
+        }
+        catch ( Exception e )
+        {
+            e.printStackTrace();
+            System.exit( 1 );
+        }
+    }
+
+    public void framesToGif()
+    {
+        if ( !active )
+        {
+            return;
+        }
+        String cmd = String.format( "convert -delay 10 -loop 0 %s*.png %sanimation.gif",
+            recordingDir, recordingDir );
+        try
+        {
+            Runtime.getRuntime().exec( cmd );
+            System.out.printf( "Wrote:  %sanimation.gif\n", recordingDir );
+        }
+        catch ( IOException e )
+        {
+            System.err.println( "convert from ImageMagick is required to make animated gifs" );
+            e.printStackTrace();
+        }
+    }
+}

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/MenuUi.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/MenuUi.java
@@ -376,7 +376,8 @@ public class MenuUi
                     frame,
                     sound,
                     MenuUi.this,
-                    SwingGameLaunch.NOT_DEMO_MODE
+                    SwingGameLaunch.NOT_DEMO_MODE,
+                    false
                 ).launchGame(
                     new String[] { filename },
                     levelWinListener

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingGameLaunch.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingGameLaunch.java
@@ -65,6 +65,7 @@ public class SwingGameLaunch implements GameLaunch
     private final MainJFrame frame;
     public final SolutionRecorderTemplate solutionRecorder;
     private final SwingPlayback swingPlayback;
+    private final FrameDumper frameDumper;
 
     /**
      * @param solutionIndex natural number values indicate demo mode. It is the index of the
@@ -77,15 +78,25 @@ public class SwingGameLaunch implements GameLaunch
         SwingSound sound,
         IConfig config,
         PrintStream debugout,
-        int solutionIndex
+        int solutionIndex,
+        boolean frameDumping
     )
     {
         this.world = world;
         SolutionInterpreter solutionInterpreter = createSolutionInterpreter( solutionIndex, world );
         this.frame = init.frame;
         this.solutionRecorder = new SolutionRecorder();
+        if ( frameDumping )
+        {
+            this.frameDumper = new FrameDumper();
+        }
+        else
+        {
+            this.frameDumper = FrameDumper.createInactiveDumper();
+        }
         this.swingPlayback = new SwingPlayback( this );
-        this.physics = new GeneralPhysics( world, winListener, solutionRecorder, solutionInterpreter, swingPlayback );
+        this.physics = new GeneralPhysics( world, winListener, 
+            solutionRecorder, solutionInterpreter, swingPlayback, frameDumping );
 
         // This blocks until the UI is ready:
         WhenUiReady uiPieces = init.waitForUi.waitForUi();
@@ -95,7 +106,8 @@ public class SwingGameLaunch implements GameLaunch
             world,
             uiPieces.jframe,
             uiPieces.bitmapCache,
-            sound
+            sound,
+            frameDumper
         );
 
         jframe.setGameLaunch( this );

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingGraphics.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingGraphics.java
@@ -88,6 +88,7 @@ public class SwingGraphics implements Graphics
     private final GameUi jframe;
     private final BufferStrategy strategy;
     private final SpriteAnimator animator;
+    private final FrameDumper frameDumper;
 
     public final Renderer<SwingBitmap, SwingPaint> renderer;
     private final SoundPlayer soundPlayer;
@@ -100,7 +101,8 @@ public class SwingGraphics implements Graphics
         World world,
         GameUi jframe,
         BitmapCache<SwingBitmap> bitmapCache,
-        SwingSound sound
+        SwingSound sound,
+        FrameDumper frameDumper
     )
     {
         this.world = world;
@@ -117,6 +119,7 @@ public class SwingGraphics implements Graphics
         this.prevScrollX = -1;
         this.prevScrollY = -1;
         this.lastWorldState = null;
+        this.frameDumper = frameDumper;
     }
 
     @Override
@@ -124,7 +127,7 @@ public class SwingGraphics implements Graphics
     {
         setRendererOffset( renderer );
 
-        new DrawFrame(
+        DrawFrame df = new DrawFrame(
             strategy,
             jframe.canvas,
             renderer,
@@ -132,7 +135,11 @@ public class SwingGraphics implements Graphics
             animator,
             frame,
             world
-        ).run();
+        );
+
+        df.run();
+
+        frameDumper.dump( jframe.canvas, df );
     }
 
     public void setTileSize( int timeSize )

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingSingleGameEntryPoint.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingSingleGameEntryPoint.java
@@ -27,6 +27,7 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
     private final SwingSound sound;
     private final MenuUi menuUi;
     private final int solutionIndex;
+    private final boolean frameDumping;
 
     public SwingSingleGameEntryPoint(
         FileSystem fs,
@@ -37,7 +38,8 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
         MainJFrame frame,
         SwingSound sound,
         MenuUi menuUi,
-        int solutionIndex
+        int solutionIndex,
+        boolean frameDumping
     )
     {
         super( fs, out, locale );
@@ -47,22 +49,24 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
         this.sound = sound;
         this.menuUi = menuUi;
         this.solutionIndex = solutionIndex;
+        this.frameDumping = frameDumping;
     }
 
     public static void entryPoint( String[] args )
     {
         if ( 1 == args.length && args[0].endsWith( ".rel" ) )
         { // Single arg must level file
-            go( args, SwingGameLaunch.NOT_DEMO_MODE );
+            go( args, SwingGameLaunch.NOT_DEMO_MODE, false );
             System.exit( 0 );
         }
 
         CommandLineOption level =        new CommandLineOption( "--level",        true );
         CommandLineOption solution =     new CommandLineOption( "--solution",     true );
         CommandLineOption anim =         new CommandLineOption( "--animation",    false );
+        CommandLineOption dump =         new CommandLineOption( "--dump",         false );
 
         CommandLineOptionSet.parse( args,
-                                    level, solution, anim);
+                                    level, solution, anim, dump);
         try
         {
             if ( anim.isPresent() )
@@ -72,12 +76,12 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
             }
             if ( solution.isPresent() )
             {
-                go( new String[] {level.getValue()}, solution.getInt() );
+                go( new String[] {level.getValue()}, solution.getInt(), dump.isPresent() );
                 System.exit( 0 );
             }
             if ( level.isPresent() )
             {
-                go( new String[] {level.getValue()}, SwingGameLaunch.NOT_DEMO_MODE );
+                go( new String[] {level.getValue()}, SwingGameLaunch.NOT_DEMO_MODE, false );
                 System.exit( 0 );
             }
         }
@@ -89,7 +93,7 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
 
     }
 
-    private static void go( String[] fileName, int solutionIndex )
+    private static void go( String[] fileName, int solutionIndex, boolean frameDumping )
     {
 
         Config cfg = SwingConfigSetup.createConfig();
@@ -110,7 +114,8 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
             new MainJFrame( cfg, sound ),
             sound,
             null,
-            solutionIndex
+            solutionIndex,
+            frameDumping
         );
 
         m.run( fileName );
@@ -126,6 +131,6 @@ public class SwingSingleGameEntryPoint extends SingleGameEntryPoint
         SwingUtilities.invokeLater( init );
 
         return new SwingGameLaunch(
-            init, world, winListener, sound, uiConfig, out, solutionIndex );
+            init, world, winListener, sound, uiConfig, out, solutionIndex, frameDumping );
     }
 }


### PR DESCRIPTION
This is slow. On my debian VM its not possible to play and dump frames. Also creating the gif after is slow, even for ImageMagick, so trying to do it in java may not be sensible.

These things may be tractable if the resolution is dropped for the dumped frames.

I think this is useful as it is: it allows the creation of high quality video. 