### PR TITLE
thickness of lines in rabbit block frames set to 1 pixel

### DIFF
--- a/images-src/rabbit_block_01.svg
+++ b/images-src/rabbit_block_01.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_01.svg">
   <defs
      id="defs4" />
@@ -26,14 +26,14 @@
      inkscape:pageshadow="2"
      inkscape:zoom="26.59375"
      inkscape:cx="16"
-     inkscape:cy="16"
+     inkscape:cy="14.495887"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -54,123 +54,103 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 c 0,4.771741 -2.403733,8.640001 -5.368889,8.640001 -2.965155,0 -5.3688886,-3.86826 -5.3688886,-8.640001 0,-4.77174 2.4037336,-8.64 5.3688886,-8.64 2.965156,0 5.368889,3.86826 5.368889,8.64 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792-5"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.05016844;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 c 0,0.9032924 -1.512283,1.6355555 -3.377778,1.6355555 -1.8654953,0 -3.3777779,-0.7322631 -3.3777779,-1.6355555 0,-0.9032924 1.5122826,-1.6355555 3.3777779,-1.6355555 1.865495,0 3.377778,0.7322631 3.377778,1.6355555 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.05887328,0.89395321,-1.0119555,0.03563041,20.663023,1020.3338)" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.09291141;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 c 0,0.9032924 -1.512283,1.6355555 -3.377778,1.6355555 -1.8654953,0 -3.3777779,-0.7322631 -3.3777779,-1.6355555 0,-0.9032924 1.5122826,-1.6355555 3.3777779,-1.6355555 1.865495,0 3.377778,0.7322631 3.377778,1.6355555 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(-0.0697279,0.93890486,-0.88603064,-0.07605537,26.462996,1020.8584)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.15911512;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 c 0,2.1796836 -2.164952,3.9466666 -4.835555,3.9466666 -2.670604,0 -4.835556,-1.766983 -4.835556,-3.9466666 0,-2.1796839 2.164952,-3.9466668 4.835556,-3.9466668 2.670603,0 4.835555,1.7669829 4.835555,3.9466668 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(0.526668,0.57580958,-0.64758442,0.7052122,14.072327,1017.9387)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        transform="translate(-5.0773541,1024.4391)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
     <path
        transform="translate(-2.0851461,1024.2469)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4-3"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
   </g>
 </svg>

--- a/images-src/rabbit_block_02.svg
+++ b/images-src/rabbit_block_02.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_02.svg">
   <defs
      id="defs4" />
@@ -25,15 +25,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="26.59375"
-     inkscape:cx="16"
-     inkscape:cy="16"
+     inkscape:cx="10.359577"
+     inkscape:cy="12.991774"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -54,123 +54,103 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 c 0,4.771741 -2.403733,8.640001 -5.368889,8.640001 -2.965155,0 -5.3688886,-3.86826 -5.3688886,-8.640001 0,-4.77174 2.4037336,-8.64 5.3688886,-8.64 2.965156,0 5.368889,3.86826 5.368889,8.64 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792-5"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.17263751;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 c 0,0.9032924 -1.512283,1.6355555 -3.377778,1.6355555 -1.8654953,0 -3.3777779,-0.7322631 -3.3777779,-1.6355555 0,-0.9032924 1.5122826,-1.6355555 3.3777779,-1.6355555 1.865495,0 3.377778,0.7322631 3.377778,1.6355555 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(-0.00564597,0.91057899,-0.79840092,-0.03967083,21.052543,1020.3649)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.1024213;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 c 0,2.1796836 -2.164952,3.9466666 -4.835555,3.9466666 -2.670604,0 -4.835556,-1.766983 -4.835556,-3.9466666 0,-2.1796839 2.164952,-3.9466668 4.835556,-3.9466668 2.670603,0 4.835555,1.7669829 4.835555,3.9466668 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(0.58552975,0.57256501,-0.71996009,0.70123847,13.371889,1018.0323)" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.12541926;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 c 0,0.9032924 -1.512283,1.6355555 -3.377778,1.6355555 -1.8654953,0 -3.3777779,-0.7322631 -3.3777779,-1.6355555 0,-0.9032924 1.5122826,-1.6355555 3.3777779,-1.6355555 1.865495,0 3.377778,0.7322631 3.377778,1.6355555 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(-0.15064928,0.93162182,-0.82124471,-0.16226679,27.540301,1021.9078)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        transform="translate(-3.1300163,1024.719)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
     <path
        transform="translate(-6.5518729,1023.7037)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4-4"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
   </g>
 </svg>

--- a/images-src/rabbit_block_03.svg
+++ b/images-src/rabbit_block_03.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_03.svg">
   <defs
      id="defs4" />
@@ -25,15 +25,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="26.59375"
-     inkscape:cx="16"
-     inkscape:cy="16"
+     inkscape:cx="10.359577"
+     inkscape:cy="12.991774"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -54,123 +54,103 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 c 0,4.771741 -2.403733,8.640001 -5.368889,8.640001 -2.965155,0 -5.3688886,-3.86826 -5.3688886,-8.640001 0,-4.77174 2.4037336,-8.64 5.3688886,-8.64 2.965156,0 5.368889,3.86826 5.368889,8.64 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792-5"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.17263751;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(-0.00564597,0.91057899,-0.79840092,-0.03967083,21.621931,1020.5153)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.08619685;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770-7"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 a 4.8355556,3.9466667 0 1 1 -9.671111,0 4.8355556,3.9466667 0 1 1 9.671111,0 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(-0.87317333,0.17144822,0.14907005,0.94142425,28.485424,1022.5485)" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.12541926;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(-0.15064928,0.93162182,-0.82124471,-0.16226679,26.354801,1022.1114)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z"
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z"
        transform="matrix(-1,0,0,1,34.498879,1024.3325)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-2"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z"
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z"
        transform="matrix(-1,0,0,1,32.357528,1023.449)" />
   </g>
 </svg>

--- a/images-src/rabbit_block_04.svg
+++ b/images-src/rabbit_block_04.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_04.svg">
   <defs
      id="defs4" />
@@ -25,15 +25,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="18.804621"
-     inkscape:cx="10.883416"
+     inkscape:cx="2.9066533"
      inkscape:cy="15.197857"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -43,7 +43,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -54,123 +54,103 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 1 1 -10.7377776,0 5.3688889,8.6400003 0 1 1 10.7377776,0 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792-5"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 1 1 -2.844445,0 1.4222223,3.8044446 0 1 1 2.844445,0 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 1 1 -2.844445,0 1.4222223,3.8044446 0 1 1 2.844445,0 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.1270684;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(-0.00614619,0.90547633,-0.86913767,-0.03944852,21.250217,1020.3089)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 a 3.6977777,2.2755556 0 1 1 -7.395556,0 3.6977777,2.2755556 0 1 1 7.395556,0 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 a 3.3777778,1.1733333 0 1 1 -6.755556,0 3.3777778,1.1733333 0 1 1 6.755556,0 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 a 3.6977777,2.2755556 0 1 1 -7.395556,0 3.6977777,2.2755556 0 1 1 7.395556,0 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 a 3.3777778,1.1733333 0 1 1 -6.755556,0 3.3777778,1.1733333 0 1 1 6.755556,0 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.13851339;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770-7"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 a 4.8355556,3.9466667 0 1 1 -9.671111,0 4.8355556,3.9466667 0 1 1 9.671111,0 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(-0.79037887,0.17240065,0.1349352,0.94665408,27.622986,1022.3306)" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.12541926;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(-0.15064928,0.93162182,-0.82124471,-0.16226679,26.90216,1021.4292)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z"
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z"
        transform="matrix(-1,0,0,1,36.003451,1024.6075)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-7"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z"
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z"
        transform="matrix(-1,0,0,1,33.170779,1023.6177)" />
   </g>
 </svg>

--- a/images-src/rabbit_block_05.svg
+++ b/images-src/rabbit_block_05.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_05.svg">
   <defs
      id="defs4" />
@@ -25,15 +25,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="26.59375"
-     inkscape:cx="16"
-     inkscape:cy="16"
+     inkscape:cx="10.359577"
+     inkscape:cy="11.84459"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -54,123 +54,103 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 c 0,4.771741 -2.403733,8.640001 -5.368889,8.640001 -2.965155,0 -5.3688886,-3.86826 -5.3688886,-8.640001 0,-4.77174 2.4037336,-8.64 5.3688886,-8.64 2.965156,0 5.368889,3.86826 5.368889,8.64 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792-5"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07894479;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 c 0,0.9032924 -1.512283,1.6355555 -3.377778,1.6355555 -1.8654953,0 -3.3777779,-0.7322631 -3.3777779,-1.6355555 0,-0.9032924 1.5122826,-1.6355555 3.3777779,-1.6355555 1.865495,0 3.377778,0.7322631 3.377778,1.6355555 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.05705115,0.89783423,-0.95494882,0.02858601,20.407397,1019.9756)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.09215009;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 c 0,0.9032924 -1.512283,1.6355555 -3.377778,1.6355555 -1.8654953,0 -3.3777779,-0.7322631 -3.3777779,-1.6355555 0,-0.9032924 1.5122826,-1.6355555 3.3777779,-1.6355555 1.865495,0 3.377778,0.7322631 3.377778,1.6355555 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(-0.10772182,0.93430281,-0.8837196,-0.11796644,26.514046,1020.9053)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.17163372;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770-7"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 c 0,2.1796836 -2.164952,3.9466666 -4.835555,3.9466666 -2.670604,0 -4.835556,-1.766983 -4.835556,-3.9466666 0,-2.1796839 2.164952,-3.9466668 4.835556,-3.9466668 2.670603,0 4.835555,1.7669829 4.835555,3.9466668 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(-0.60964249,0.46006221,0.50161229,0.81638808,21.217768,1018.786)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z"
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z"
        transform="matrix(-1,0,0,1,37.376966,1024.3728)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-7"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z"
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z"
        transform="matrix(-1,0,0,1,34.593693,1024.3934)" />
   </g>
 </svg>

--- a/images-src/rabbit_block_06.svg
+++ b/images-src/rabbit_block_06.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_06.svg">
   <defs
      id="defs4" />
@@ -24,16 +24,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="13.296875"
-     inkscape:cx="14.906876"
-     inkscape:cy="6.9991029"
+     inkscape:zoom="18.804621"
+     inkscape:cx="19.337225"
+     inkscape:cy="11.554371"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -54,123 +54,98 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 c 0,4.771741 -2.403733,8.640001 -5.368889,8.640001 -2.965155,0 -5.3688886,-3.86826 -5.3688886,-8.640001 0,-4.77174 2.4037336,-8.64 5.3688886,-8.64 2.965156,0 5.368889,3.86826 5.368889,8.64 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
-       id="path3792-5"
-       sodipodi:cx="19.768888"
-       sodipodi:cy="22.151112"
-       sodipodi:rx="1.4222223"
-       sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
-       transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
+       transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
+       id="path3792-5" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.18187596;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.07931449,0.94607493,-0.75051541,0.0739148,22.424198,1019.1748)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.10683823;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770-7"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 a 4.8355556,3.9466667 0 1 1 -9.671111,0 4.8355556,3.9466667 0 1 1 9.671111,0 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(-0.76502163,0.29257914,0.38675368,0.91907196,25.435211,1020.5855)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.14104129;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.15712548,0.88945672,-0.83560791,0.15800553,17.511807,1019.8482)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z"
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z"
        transform="matrix(-1,0,0,1,38.667717,1023.7695)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-7"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z"
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z"
        transform="matrix(-1,0,0,1,35.831265,1024.3494)" />
   </g>
 </svg>

--- a/images-src/rabbit_block_07.svg
+++ b/images-src/rabbit_block_07.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_07.svg">
   <defs
      id="defs4" />
@@ -25,15 +25,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="26.59375"
-     inkscape:cx="16"
-     inkscape:cy="16"
+     inkscape:cx="10.359577"
+     inkscape:cy="12.991774"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -54,123 +54,103 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 c 0,4.771741 -2.403733,8.640001 -5.368889,8.640001 -2.965155,0 -5.3688886,-3.86826 -5.3688886,-8.640001 0,-4.77174 2.4037336,-8.64 5.3688886,-8.64 2.965156,0 5.368889,3.86826 5.368889,8.64 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792-5"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.24783674;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.07065687,0.95269067,-0.6685925,0.07443167,20.957148,1019.2006)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.13501043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 a 4.8355556,3.9466667 0 1 1 -9.671111,0 4.8355556,3.9466667 0 1 1 9.671111,0 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(0.79554669,0.17233962,-0.13581747,0.94631896,5.2171997,1022.2819)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.19558234;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.14217428,0.89535269,-0.75609604,0.15905291,18.21262,1019.8059)" />
     <path
        transform="translate(-2.5268545,1024.3637)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
     <path
        transform="translate(0.13715875,1023.3802)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4-8"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
   </g>
 </svg>

--- a/images-src/rabbit_block_08.svg
+++ b/images-src/rabbit_block_08.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_08.svg">
   <defs
      id="defs4" />
@@ -25,15 +25,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="26.59375"
-     inkscape:cx="16"
-     inkscape:cy="16"
+     inkscape:cx="10.359577"
+     inkscape:cy="14.354275"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -54,123 +54,103 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 c 0,4.771741 -2.403733,8.640001 -5.368889,8.640001 -2.965155,0 -5.3688886,-3.86826 -5.3688886,-8.640001 0,-4.77174 2.4037336,-8.64 5.3688886,-8.64 2.965156,0 5.368889,3.86826 5.368889,8.64 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792-5"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.20268059;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.07642003,0.94577064,-0.72312655,0.09736205,22.311876,1019.0812)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.12469965;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 a 4.8355556,3.9466667 0 1 1 -9.671111,0 4.8355556,3.9466667 0 1 1 9.671111,0 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(0.81105582,0.17215778,-0.13846522,0.94532045,5.4763981,1022.3323)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.13267212;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.15962741,0.88850175,-0.84891338,0.15783589,18.489658,1020.0291)" />
     <path
        transform="translate(-2.1664019,1024.1666)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
     <path
        transform="translate(0.61309217,1023.4426)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4-3"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
   </g>
 </svg>

--- a/images-src/rabbit_block_09.svg
+++ b/images-src/rabbit_block_09.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_09.svg">
   <defs
      id="defs4" />
@@ -25,15 +25,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="26.59375"
-     inkscape:cx="16"
-     inkscape:cy="16"
+     inkscape:cx="10.359577"
+     inkscape:cy="12.991774"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -54,123 +54,103 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 c 0,4.771741 -2.403733,8.640001 -5.368889,8.640001 -2.965155,0 -5.3688886,-3.86826 -5.3688886,-8.640001 0,-4.77174 2.4037336,-8.64 5.3688886,-8.64 2.965156,0 5.368889,3.86826 5.368889,8.64 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792-5"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.13432484;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.01647354,0.94220537,-0.82424107,0.03532313,24.867453,1019.8464)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.09348787;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.09573599,0.89534676,-0.9257441,0.07789342,19.783972,1020.7179)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.15286977;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 a 4.8355556,3.9466667 0 1 1 -9.671111,0 4.8355556,3.9466667 0 1 1 9.671111,0 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(0.69680062,0.36978442,-0.37709168,0.87965087,9.4561405,1019.8128)" />
     <path
        transform="translate(-3.5710681,1024.7424)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
     <path
        transform="translate(-0.57886025,1024.2843)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4-3"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
   </g>
 </svg>

--- a/images-src/rabbit_block_10.svg
+++ b/images-src/rabbit_block_10.svg
@@ -13,7 +13,7 @@
    height="32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="rabbit_block_10.svg">
   <defs
      id="defs4" />
@@ -25,15 +25,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="26.59375"
-     inkscape:cx="16"
-     inkscape:cy="16"
+     inkscape:cx="10.359577"
+     inkscape:cy="12.991774"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1031"
+     inkscape:window-height="980"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -54,123 +54,103 @@
      transform="translate(0,-1020.3622)">
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.07208043;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3768"
        sodipodi:cx="13.262222"
        sodipodi:cy="21.297777"
        sodipodi:rx="5.3688889"
        sodipodi:ry="8.6400003"
-       d="m 18.631111,21.297777 c 0,4.771741 -2.403733,8.640001 -5.368889,8.640001 -2.965155,0 -5.3688886,-3.86826 -5.3688886,-8.640001 0,-4.77174 2.4037336,-8.64 5.3688886,-8.64 2.965156,0 5.368889,3.86826 5.368889,8.64 z"
+       d="m 18.631111,21.297777 a 5.3688889,8.6400003 0 0 1 -5.368889,8.640001 5.3688889,8.6400003 0 0 1 -5.3688886,-8.640001 5.3688889,8.6400003 0 0 1 5.3688886,-8.64 5.3688889,8.6400003 0 0 1 5.368889,8.64 z"
        transform="matrix(1.0062535,-0.00342271,0.00398334,0.8646315,3.4496481,1026.465)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.9880876;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792-5"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.47398993,-0.90302053,0.87852584,-0.48720552,14.216632,1067.7971)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:0.99999999;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3792"
        sodipodi:cx="19.768888"
        sodipodi:cy="22.151112"
        sodipodi:rx="1.4222223"
        sodipodi:ry="3.8044446"
-       d="m 21.191111,22.151112 c 0,2.101136 -0.636751,3.804444 -1.422223,3.804444 -0.785471,0 -1.422222,-1.703308 -1.422222,-3.804444 0,-2.101137 0.636751,-3.804445 1.422222,-3.804445 0.785472,0 1.422223,1.703308 1.422223,3.804445 z"
+       d="m 21.191111,22.151112 a 1.4222223,3.8044446 0 0 1 -1.422223,3.804444 1.4222223,3.8044446 0 0 1 -1.422222,-3.804444 1.4222223,3.8044446 0 0 1 1.422222,-3.804445 1.4222223,3.8044446 0 0 1 1.422223,3.804445 z"
        transform="matrix(-0.28285606,0.95916238,-0.95916238,-0.28285606,36.049425,1027.1475)" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 14.530658,1048.6988 a 1.9462298,3.2893836 0.99691166 0 1 -2.000042,3.2605 1.9462298,3.2893836 0.99691166 0 1 -1.892013,-3.3173 1.9462298,3.2893836 0.99691166 0 1 2.000042,-3.2605 1.9462298,3.2893836 0.99691166 0 1 1.892013,3.3173 z"
        id="path3796"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(0.52626937,0.00768747,-0.0237369,1.4453337,5.9878197,1008.1721)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 14.861256,1051.3426 a 1.1225084,2.0604898 89.923646 0 1 -2.055932,1.1269 1.1225084,2.0604898 89.923646 0 1 -2.065035,-1.1181 1.1225084,2.0604898 89.923646 0 1 2.055932,-1.1269 1.1225084,2.0604898 89.923646 0 1 2.065035,1.1181 z"
        id="path3766"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(0.61001154,-0.00130569,0.00387887,0.95667793,1.9936161,1023.1713)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.383908,1048.8276 a 3.2893836,1.9462298 89.003088 0 0 2.000042,3.2605 3.2893836,1.9462298 89.003088 0 0 1.892012,-3.3173 3.2893836,1.9462298 89.003088 0 0 -2.000041,-3.2605 3.2893836,1.9462298 89.003088 0 0 -1.892013,3.3173 z"
        id="path3796-7"
-       sodipodi:cx="13.795555"
-       sodipodi:cy="27.946667"
-       sodipodi:rx="3.6977777"
-       sodipodi:ry="2.2755556"
-       d="m 17.493333,27.946667 c 0,1.256754 -1.655552,2.275555 -3.697778,2.275555 -2.042226,0 -3.697778,-1.018801 -3.697778,-2.275555 0,-1.256755 1.655552,-2.275556 3.697778,-2.275556 2.042226,0 3.697778,1.018801 3.697778,2.275556 z"
-       transform="matrix(-0.52626937,0.00768747,0.0237369,1.4453337,27.926746,1008.3009)" />
+       inkscape:connector-curvature="0" />
     <path
-       sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.05331,1051.4714 a 2.0604898,1.1225084 0.07635384 0 0 2.055932,1.1269 2.0604898,1.1225084 0.07635384 0 0 2.065035,-1.1181 2.0604898,1.1225084 0.07635384 0 0 -2.055932,-1.1269 2.0604898,1.1225084 0.07635384 0 0 -2.065035,1.1181 z"
        id="path3766-8"
-       sodipodi:cx="17.528889"
-       sodipodi:cy="29.475555"
-       sodipodi:rx="3.3777778"
-       sodipodi:ry="1.1733333"
-       d="m 20.906667,29.475555 c 0,0.648015 -1.512283,1.173334 -3.377778,1.173334 -1.865495,0 -3.377778,-0.525319 -3.377778,-1.173334 0,-0.648014 1.512283,-1.173333 3.377778,-1.173333 1.865495,0 3.377778,0.525319 3.377778,1.173333 z"
-       transform="matrix(-0.61001154,-0.00130569,-0.00387887,0.95667793,31.92095,1023.3001)" />
+       inkscape:connector-curvature="0" />
     <path
        sodipodi:type="arc"
-       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#4d4d4b;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.09188737;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772-7"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(-0.05850616,0.93573415,-0.89474295,-0.02617202,26.445925,1020.2896)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.09348788;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3772"
        sodipodi:cx="10.204445"
        sodipodi:cy="7.6088891"
        sodipodi:rx="3.3777778"
        sodipodi:ry="1.6355555"
-       d="m 13.582223,7.6088891 a 3.3777778,1.6355555 0 1 1 -6.7555559,0 3.3777778,1.6355555 0 1 1 6.7555559,0 z"
+       d="M 13.582223,7.6088891 A 3.3777778,1.6355555 0 0 1 10.204445,9.2444446 3.3777778,1.6355555 0 0 1 6.8266671,7.6088891 3.3777778,1.6355555 0 0 1 10.204445,5.9733336 3.3777778,1.6355555 0 0 1 13.582223,7.6088891 Z"
        transform="matrix(0.13775121,0.88985156,-0.92105464,0.12135843,19.144436,1019.7676)" />
     <path
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1.15286977;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3770"
        sodipodi:cx="16.782223"
        sodipodi:cy="9.8488894"
        sodipodi:rx="4.8355556"
        sodipodi:ry="3.9466667"
-       d="m 21.617778,9.8488894 a 4.8355556,3.9466667 0 1 1 -9.671111,0 4.8355556,3.9466667 0 1 1 9.671111,0 z"
+       d="M 21.617778,9.8488894 A 4.8355556,3.9466667 0 0 1 16.782223,13.795556 4.8355556,3.9466667 0 0 1 11.946667,9.8488894 4.8355556,3.9466667 0 0 1 16.782223,5.9022226 4.8355556,3.9466667 0 0 1 21.617778,9.8488894 Z"
        transform="matrix(0.69680062,0.36978442,-0.37709168,0.87965087,8.9087808,1019.5093)" />
     <path
        transform="translate(-4.7033904,1024.173)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
     <path
        transform="translate(-1.7111826,1023.9808)"
        sodipodi:type="arc"
-       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
        id="path3794-4-3"
        sodipodi:cx="20.088888"
        sodipodi:cy="9.7066669"
        sodipodi:rx="0.39111111"
        sodipodi:ry="0.39111111"
-       d="m 20.479999,9.7066669 a 0.39111111,0.39111111 0 1 1 -0.782222,0 0.39111111,0.39111111 0 1 1 0.782222,0 z" />
+       d="M 20.479999,9.7066669 A 0.39111111,0.39111111 0 0 1 20.088888,10.097778 0.39111111,0.39111111 0 0 1 19.697777,9.7066669 0.39111111,0.39111111 0 0 1 20.088888,9.3155558 0.39111111,0.39111111 0 0 1 20.479999,9.7066669 Z" />
   </g>
 </svg>


### PR DESCRIPTION
a few of the lines were a little off 1 pixel thick. the legs and feet had variable thickness. I think this may even be a bug in inkscape. fix is to 
- select all the problem ellipses,
- convert to path (shift-ctrl-c),
- tap the selected object's resize handle (without resizing)
- translate up and back with arrow keys
and the lines become uniform thickness.
