### PR TITLE
update gradle version to 2.1.0

### DIFF
--- a/rabbit-escape-ui-android/build.gradle
+++ b/rabbit-escape-ui-android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
i do wonder if just ignoring build.gradle would be a good idea.

studio has 2.1.0 on stable, and this comes with it.