### PR TITLE
use level names in menus

### DIFF
--- a/rabbit-escape-engine/src/rabbitescape/engine/menu/LevelMenuItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/menu/LevelMenuItem.java
@@ -7,12 +7,14 @@ public class LevelMenuItem extends MenuItem
     public final String fileName;
     public final String levelsDir;
     public final int levelNumber;
+    public final String name;
 
     public LevelMenuItem(
-        String fileName, String levelsDir, int number, boolean enabled )
+        String fileName, String levelsDir, int number, boolean enabled,
+        String levelName )
     {
         super(
-            "Level ${number}",
+            "${number} " + levelName,
             Type.LEVEL,
             newMap( "number", String.valueOf( number ) ),
             enabled
@@ -21,6 +23,7 @@ public class LevelMenuItem extends MenuItem
         this.fileName = fileName;
         this.levelsDir = levelsDir;
         this.levelNumber = number;
+        this.name = levelName;
     }
 
 }

--- a/rabbit-escape-engine/src/rabbitescape/engine/menu/LevelsMenu.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/menu/LevelsMenu.java
@@ -48,7 +48,8 @@ public class LevelsMenu extends Menu
                 levelsDir + "/" + info.object.fileName + ".rel",
                 levelsDir,
                 info.index,
-                true
+                true,
+                info.object.name
             );
         }
 

--- a/rabbit-escape-engine/test/rabbitescape/engine/menu/TestLevelsMenu.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/menu/TestLevelsMenu.java
@@ -25,9 +25,9 @@ public class TestLevelsMenu
             menuItemsToStrings( menu.items ),
             equalTo(
                 new String[] {
-                    "Level 1 test2/lev1.rel",
-                    "Level 2 test2/lev2.rel (disabled)",
-                    "Level 3 test2/lev3.rel (disabled)"
+                    "LeVeL test2 1 test2/lev1.rel",
+                    "LeVeL test2 2 test2/lev2.rel (disabled)",
+                    "LeVeL test2 3 test2/lev3.rel (disabled)"
                 }
             )
         );
@@ -49,9 +49,9 @@ public class TestLevelsMenu
             menuItemsToStrings( menu.items ),
             equalTo(
                 new String[] {
-                    "Level 1 test2/lev1.rel",
-                    "Level 2 test2/lev2.rel",
-                    "Level 3 test2/lev3.rel (disabled)"
+                    "LeVeL test2 1 test2/lev1.rel",
+                    "LeVeL test2 2 test2/lev2.rel",
+                    "LeVeL test2 3 test2/lev3.rel (disabled)"
                 }
             )
         );
@@ -73,9 +73,9 @@ public class TestLevelsMenu
             menuItemsToStrings( menu.items ),
             equalTo(
                 new String[] {
-                    "Level 1 test2/lev1.rel",
-                    "Level 2 test2/lev2.rel",
-                    "Level 3 test2/lev3.rel"
+                    "LeVeL test2 1 test2/lev1.rel",
+                    "LeVeL test2 2 test2/lev2.rel",
+                    "LeVeL test2 3 test2/lev3.rel"
                 }
             )
         );
@@ -97,9 +97,9 @@ public class TestLevelsMenu
             menuItemsToStrings( menu.items ),
             equalTo(
                 new String[] {
-                    "Level 1 test2/lev1.rel",
-                    "Level 2 test2/lev2.rel",
-                    "Level 3 test2/lev3.rel"
+                    "LeVeL test2 1 test2/lev1.rel",
+                    "LeVeL test2 2 test2/lev2.rel",
+                    "LeVeL test2 3 test2/lev3.rel"
                 }
             )
         );
@@ -122,9 +122,9 @@ public class TestLevelsMenu
             menuItemsToStrings( menu.items ),
             equalTo(
                 new String[] {
-                    "Level 1 test2/lev1.rel",
-                    "Level 2 test2/lev2.rel",
-                    "Level 3 test2/lev3.rel (disabled)"
+                    "LeVeL test2 1 test2/lev1.rel",
+                    "LeVeL test2 2 test2/lev2.rel",
+                    "LeVeL test2 3 test2/lev3.rel (disabled)"
                 }
             )
         );
@@ -138,9 +138,9 @@ public class TestLevelsMenu
             menuItemsToStrings( menu.items ),
             equalTo(
                 new String[] {
-                    "Level 1 test2/lev1.rel",
-                    "Level 2 test2/lev2.rel",
-                    "Level 3 test2/lev3.rel"
+                    "LeVeL test2 1 test2/lev1.rel",
+                    "LeVeL test2 2 test2/lev2.rel",
+                    "LeVeL test2 3 test2/lev3.rel"
                 }
             )
         );

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/MenuUi.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/MenuUi.java
@@ -228,7 +228,7 @@ public class MenuUi
 
         menuPanel.removeAll();
 
-        Dimension buttonSize = new Dimension( 200, 40 );
+        Dimension buttonSize = new Dimension( 300, 40 );
 
         JLabel label = new JLabel( t( menu.intro ) );
         label.setHorizontalAlignment( SwingConstants.CENTER );

--- a/slowtests/hard-1.expect
+++ b/slowtests/hard-1.expect
@@ -20,7 +20,7 @@ demand "or 0 to go back: "
 
 send "3\r"
 
-demand "1. Level 1"
+demand "1. 1 Choppy"
 demand "or 0 to go back: "
 
 send "1\r"


### PR DESCRIPTION
checked on swing, text and droid

this will conflict with #418. please merge that one first, and I will resolve the merge.