### PR TITLE
fix concurrent modification of polygon list by using copy

### DIFF
--- a/rabbit-escape-render/src/rabbitescape/render/gameloop/WaterAnimation.java
+++ b/rabbit-escape-render/src/rabbitescape/render/gameloop/WaterAnimation.java
@@ -19,7 +19,7 @@ import rabbitescape.render.WaterRegionRenderer;
 public class WaterAnimation
 {
     public final LookupTable2D<WaterRegionRenderer> lookupRenderer ;
-    public final ArrayList<PolygonBuilder> polygons;
+    private final List<PolygonBuilder> polygons;
     private int lastFramenumber = 10;
     public final Dimension worldSize;
 
@@ -40,6 +40,11 @@ public class WaterAnimation
     public static WaterAnimation getDummyWaterAnimation()
     {
         return new WaterAnimation();
+    }
+
+    public synchronized List<PolygonBuilder> getPolygons()
+    {
+        return new ArrayList<PolygonBuilder>( polygons );
     }
 
     /**

--- a/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingGraphics.java
+++ b/rabbit-escape-ui-swing/src/rabbitescape/ui/swing/SwingGraphics.java
@@ -3,7 +3,6 @@ package rabbitescape.ui.swing;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferStrategy;
-import java.util.ArrayList;
 import java.util.List;
 
 import rabbitescape.engine.Thing;
@@ -90,7 +89,7 @@ public class SwingGraphics implements Graphics
                 graphPaperMinor
             );
 
-            drawPolygons( waterAnimation.polygons, swingCanvas );
+            drawPolygons( waterAnimation, swingCanvas );
 
             List<Sprite> sprites = animator.getSprites( frameNum );
 
@@ -143,11 +142,11 @@ public class SwingGraphics implements Graphics
             }
         }
 
-        void drawPolygons( ArrayList<PolygonBuilder> polygons,
+        synchronized void drawPolygons( WaterAnimation wa,
             SwingCanvas swingCanvas )
         {
             float f = renderer.tileSize / 32f;
-            for ( PolygonBuilder pb: polygons )
+            for ( PolygonBuilder pb: wa.getPolygons()  )
             {
                 Path p = pb.path( f,
                     new Vertex( renderer.offsetX, renderer.offsetY ) );


### PR DESCRIPTION
fixes #442 

This stops the exception. Its still a bit flickery. the flicker is much less bad using JRE 8, as the poly rendering is faster.

I think the flickering is not fundamentally the fault of the water polys. I think its to do with the redraw method. i will look some more.