### PR TITLE
fix expect tests: levels have names in filenames

### DIFF
--- a/expecttests/runrabbit--level.expect
+++ b/expecttests/runrabbit--level.expect
@@ -2,7 +2,7 @@
 
 set timeout 2
 
-spawn ./runrabbit --level ./rabbit-escape-engine/src/rabbitescape/levels/01_easy/level_01.rel
+spawn ./runrabbit --level ./rabbit-escape-engine/src/rabbitescape/levels/01_easy/01_Digging-practice.rel
 
 # No menu navigation: a single level was chosen in the command line options
 

--- a/expecttests/runrabbit-l--solution.expect
+++ b/expecttests/runrabbit-l--solution.expect
@@ -2,7 +2,7 @@
 
 set timeout 2
 
-spawn ./runrabbit -l ./rabbit-escape-engine/src/rabbitescape/levels/01_easy/level_02.rel --solution=1
+spawn ./runrabbit -l ./rabbit-escape-engine/src/rabbitescape/levels/01_easy/02_Bashing-practice.rel --solution=1
 
 demand "  Saved:3"
 


### PR DESCRIPTION
fixes #584 

the android smoketest still fails after getting quite a way through, I think. this improves things.