### PR TITLE
Bash block dig bug fix

### DIFF
--- a/rabbit-escape-engine/src/rabbitescape/engine/BehaviourTools.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/BehaviourTools.java
@@ -82,6 +82,24 @@ public class BehaviourTools
         }
     }
 
+    public boolean rabbitIsBashing()
+    {
+        switch( rabbit.state)
+        {
+        case RABBIT_BASHING_RIGHT:
+        case RABBIT_BASHING_LEFT:
+        case RABBIT_BASHING_UP_RIGHT:
+        case RABBIT_BASHING_UP_LEFT:
+        case RABBIT_BASHING_USELESSLY_RIGHT:
+        case RABBIT_BASHING_USELESSLY_LEFT:
+        case RABBIT_BASHING_USELESSLY_RIGHT_UP:
+        case RABBIT_BASHING_USELESSLY_LEFT_UP:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     /**
      * Checks for the presence of a token. Removes token from the the world and returns
      * true if a token is being picked up.

--- a/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Blocking.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Blocking.java
@@ -11,6 +11,7 @@ import rabbitescape.engine.ChangeDescription.State;
 public class Blocking extends Behaviour
 {
     public boolean abilityActive = false;
+    private boolean wasBasher = false;
 
     @Override
     public void cancel()
@@ -22,7 +23,7 @@ public class Blocking extends Behaviour
     public boolean checkTriggered( Rabbit rabbit, World world )
     {
         BehaviourTools t = new BehaviourTools( rabbit, world );
-
+        wasBasher = t.rabbitIsBashing();
         return t.pickUpToken( block );
     }
 
@@ -32,6 +33,17 @@ public class Blocking extends Behaviour
         if ( abilityActive || triggered )
         {
             abilityActive = true;
+            if ( wasBasher )
+            {
+                // Bashing from a slope makes them hop up a square,
+                // this needs reversing when they change to a blocker.
+                Block below = t.blockBelow();
+                if ( BehaviourTools.isSlope( below ) )
+                {
+                    ++t.rabbit.y;
+                }
+                wasBasher = false;
+            }
             Block here = t.blockHere();
             if( BehaviourTools.isRightRiseSlope( here ) )
             {

--- a/rabbit-escape-engine/test/rabbitescape/engine/logic/TestBlocking.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/logic/TestBlocking.java
@@ -1,8 +1,13 @@
 package rabbitescape.engine.logic;
 
+import static org.hamcrest.MatcherAssert.*;
+import static rabbitescape.engine.Tools.*;
+import static rabbitescape.engine.textworld.TextWorldManip.*;
 import static rabbitescape.engine.util.WorldAssertions.*;
 
 import org.junit.Test;
+
+import rabbitescape.engine.World;
 
 public class TestBlocking
 {
@@ -492,4 +497,75 @@ public class TestBlocking
         );
 
     }
+
+    @Test
+    public void Basher_on_slope_transitions_to_blocker_on_slope()
+    {
+        World world = createWorld(
+            "  #",
+            "r* ",
+            "#  ",
+            ":*=(bkd"
+        );
+
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "  #",
+                "r~ ",
+                "#  "
+            )
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "  K",
+                " d ",
+                "#  "
+            )
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "   ",
+                " H ",
+                "#  "
+            )
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "   ",
+                " D ",
+                "#  "
+            )
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "   ",
+                " r ",
+                "#f "
+            )
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "   ",
+                "   ",
+                "#  "
+            )
+        );
+    }
+
 }


### PR DESCRIPTION
fixes #587 

I believe changing the rabbit position ```++t.rabbit.y``` in ```newState``` is naughty. I tried changing it in ```behave```, but you get at least 1 anim frame in the wrong place. This fix is simple and works. I don't mind changing it, if there is a more correct solution.

@tttppp mentioned that this might break levels on the forum. I have not managed to complete them all. If they rely on bugs, I think they should be changed.