### PR TITLE
Fix bash from bridge to dig again

### DIFF
--- a/rabbit-escape-engine/src/rabbitescape/engine/Rabbit.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/Rabbit.java
@@ -28,6 +28,9 @@ public class Rabbit extends Thing implements Comparable<Rabbit>
 
     public Direction dir;
     public boolean onSlope;
+    /** Rabbits move up 1 cell to bash from a slope.
+     *  Keep a note, so it can be undone.  */
+    public boolean slopeBashHop = false;
     public final Type type;
 
     public Rabbit( int x, int y, Direction dir, Type type )
@@ -120,6 +123,7 @@ public class Rabbit extends Thing implements Comparable<Rabbit>
         boolean done = false;
         for ( Behaviour behaviour : behaviours )
         {
+
             State thisState = behaviour.newState(
                 new BehaviourTools( this, world ), behaviour.triggered );
 
@@ -141,6 +145,22 @@ public class Rabbit extends Thing implements Comparable<Rabbit>
                 behaviour.cancel();
             }
         }
+    }
+
+    public void possiblyUndoSlopeBashHop( World world )
+    {
+        if ( !slopeBashHop )
+        {
+            return;
+        }
+        BehaviourTools t = new BehaviourTools( this, world );
+        if ( t.blockHere() != null ||
+            !BehaviourTools.isSlope( t.blockBelow() ) )
+        {
+            return;
+        }
+        ++y;
+        slopeBashHop = false;
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Bashing.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Bashing.java
@@ -99,11 +99,13 @@ public class Bashing extends Behaviour
     @Override
     public boolean behave( World world, Rabbit rabbit, State state )
     {
+
         switch ( state )
         {
             case RABBIT_BASHING_RIGHT:
             case RABBIT_BASHING_LEFT:
             {
+                rabbit.slopeBashHop = false;
                 world.changes.removeBlockAt( destX( rabbit ), rabbit.y );
                 return true;
             }
@@ -111,22 +113,26 @@ public class Bashing extends Behaviour
             case RABBIT_BASHING_UP_LEFT:
             {
                 world.changes.removeBlockAt( destX( rabbit ), rabbit.y - 1 );
+                rabbit.slopeBashHop = true;
                 rabbit.y -= 1;
                 return true;
             }
             case RABBIT_BASHING_USELESSLY_RIGHT:
             case RABBIT_BASHING_USELESSLY_LEFT:
             {
+                rabbit.slopeBashHop = false;
                 return true;
             }
             case RABBIT_BASHING_USELESSLY_RIGHT_UP:
             case RABBIT_BASHING_USELESSLY_LEFT_UP:
             {
+                rabbit.slopeBashHop = true;
                 rabbit.y -= 1;
                 return true;
             }
             default:
             {
+                rabbit.slopeBashHop = false;
                 return false;
             }
         }

--- a/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Blocking.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Blocking.java
@@ -11,7 +11,6 @@ import rabbitescape.engine.ChangeDescription.State;
 public class Blocking extends Behaviour
 {
     public boolean abilityActive = false;
-    private boolean wasBasher = false;
 
     @Override
     public void cancel()
@@ -23,7 +22,6 @@ public class Blocking extends Behaviour
     public boolean checkTriggered( Rabbit rabbit, World world )
     {
         BehaviourTools t = new BehaviourTools( rabbit, world );
-        wasBasher = t.rabbitIsBashing();
         return t.pickUpToken( block );
     }
 
@@ -32,18 +30,8 @@ public class Blocking extends Behaviour
     {
         if ( abilityActive || triggered )
         {
+            t.rabbit.possiblyUndoSlopeBashHop( t.world );
             abilityActive = true;
-            if ( wasBasher )
-            {
-                // Bashing from a slope makes them hop up a square,
-                // this needs reversing when they change to a blocker.
-                Block below = t.blockBelow();
-                if ( BehaviourTools.isSlope( below ) )
-                {
-                    ++t.rabbit.y;
-                }
-                wasBasher = false;
-            }
             Block here = t.blockHere();
             if( BehaviourTools.isRightRiseSlope( here ) )
             {

--- a/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Digging.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/behaviours/Digging.java
@@ -33,6 +33,8 @@ public class Digging extends Behaviour
             return null;
         }
 
+        t.rabbit.possiblyUndoSlopeBashHop( t.world );
+
         if ( t.rabbit.state == RABBIT_DIGGING )
         {
             stepsOfDigging = 1;

--- a/rabbit-escape-engine/src/rabbitescape/levels/development/water/Infiltrate.rel
+++ b/rabbit-escape-engine/src/rabbitescape/levels/development/water/Infiltrate.rel
@@ -2,8 +2,7 @@
 :description=One rabbit. One exit. Thirty thousand units of water.
 :author_name=tttppp
 :author_url=https://github.com/tttppp
-:solution.1.code=9pBJ=jrjBjrMrjB\p&p&p&p&p&9Ajhp.Cejrjh9pAjh1zphprj&j1AJ=ijjphprj&SjeB91Cej?jhjSp1&rjh9JS&rjjMi9p&jjpJp&CehBh1Szhzhz\J=jrjhSjp&jrjJ=jr&jjjJ&eCShBjpSAre1?\h&jSjhh-1ejr&z1zB&hejSjjJjJrhAMjizr=M1jrrjhjhrJ9MArji1p=&MBjh1S9jBr9e&1jjrh&\pz&rJM1jp&9CjrBJifCjeB&\S?jejh\i1jp1jj
-:solution.2.code=oh8~]Ch(!ax8!m~m>r>f>]Ch!!h8]f>r>>s!(mf>h~4boxh>r(m4!>h>r(m4!>>(Xf>xmT>!h>X!>rrh8!T>r>]>>!]ZT>8msXoCr&r>h>*XhT>8m rma8h8m]C>r>88(m>>]r]a>a>mXfsfx>xoro>>>!>h>f8h]r8>(>8m(h>m8]>hT4~s>!Cm8>!xZr>>>8hm>(>sr4r(>om]4>>rfsxXC>xK>>hm>88hT>(8~rm~8h>mZ>>>!!>>>aX]XMafXXxrfBx
+:solution.1=bridge;;(2,2);bash&dig&(4,2)&bash;;(3,2)&bridge;6;(4,4);bash&(3,4);block;3;(2,3);bash;(2,3);6;(4,4);block;3;(2,4);bridge&(2,4);3;(1,4);bash;5;(4,2)&dig;2;(4,1);;bridge;3;(3,4);bash;;dig&(3,3)&bash;2;(4,4);dig;;(4,3);bridge;3;(4,6);5;(4,6);;bash&(3,4)&block;4;(2,4)&bridge&bash;(2,4);bridge;;(2,4);3;bash;3;(5,2);6
 :num_rabbits=1
 :num_to_save=1
 :rabbit_delay=4

--- a/rabbit-escape-engine/src/rabbitescape/levels/staging/water/Under-pressure.rel
+++ b/rabbit-escape-engine/src/rabbitescape/levels/staging/water/Under-pressure.rel
@@ -5,7 +5,7 @@
 :hint.1.code=332s2iriROrQlRmjdl3HO[ma3OiRp|[<^iXROiQr_O||kr$sOim|OOirO3s2Oi^pO3R3
 :hint.2.code=13V7y3v1[n0[[m3779[GVnn?[HlrQn797dVIg1_3Qgd7y9nQ7[737VV77[317[?3?gV"Q7h
 :hint.3.code=@N"ioioli "ZN#>@oN 2>NN)#kl)@N@N#OioT hihhN""2N@NiThN#)p>>Np]2#x2Ti
-:solution.1.code=[y#y7$CKgIO|}ggOVy#yy}[IOh'%y[Cy#jOp7yfV#T'CA7AyO~C|IgyzT#yppgOyCK7A%O|}'CpyCy%yy}Op'_gTp#CgKI*O#yyKO#OCVyyf7y'V%yf#CAygy7#y#pCpCIjy#p7py%O~}Ty%7f'~Tj}
+:solution.1=dig&(0,4);bash;2;(0,5);(2,5);bridge;4;(0,5)&block;12;(2,4);;(0,5);12;dig;(2,4);2;bash&(5,5);11;(0,5);22
 :num_rabbits=10
 :num_to_save=8
 :rabbit_delay=18,10,5,14,4

--- a/rabbit-escape-engine/test/rabbitescape/engine/logic/TestBashing.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/logic/TestBashing.java
@@ -445,7 +445,7 @@ public class TestBashing
             "#\\#"
         );
     }
-    
+
     @Test
     public void Bashing_fails_if_first_block_is_unbreakable()
     {
@@ -544,5 +544,72 @@ public class TestBashing
                 ":n=1,0,256",
                 ":n=2,0,256"
             });
+    }
+
+    @Test
+    public void Basher_on_bridge_trans_to_digger_must_not_airwalk_after()
+    {
+        World world = createWorld(
+            "   ",
+            "r* ",
+            "## ",
+            "   ",
+            ":*=(bd"
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "   ",
+                " rI",
+                "## ",
+                "   "
+            )
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "   ",
+                " D ",
+                "## ",
+                "   "
+            )
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "   ",
+                " r ",
+                "#D ",
+                "   "
+            )
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "   ",
+                "   ",
+                "#D ",
+                "   "
+            )
+        );
+
+        world.step();
+        assertThat(
+            renderWorld( world, true, false ),
+            equalTo(
+                "   ",
+                "   ",
+                "#r ",
+                " f "
+            )
+        );
     }
 }


### PR DESCRIPTION
fixes #591.

it's a redo of #590, but covers #587 as well as #591.

It still changes rabbit coordinates outside of behave(). I couldn't make that work. I tried to put the code in Bashing, which is the cause of the problem, but could not. It had to be in Blocking and Digging.

The minimal change I came up with did result in a timing change which broke "Infiltrate" and "Under pressure". I submit new solutions for those. @tttppp might like to make another solution for "Infiltrate" if this PR is accepted.