### PR TITLE
Update gradle and gradle plugin. Fixes #600

### DIFF
--- a/rabbit-escape-ui-android/app/build.gradle
+++ b/rabbit-escape-ui-android/app/build.gradle
@@ -4,6 +4,7 @@ android {
     compileSdkVersion 21
     buildToolsVersion '25.0.0'
 
+    flavorDimensions "version"
     productFlavors {
         paid {
             applicationId "net.artificialworlds.rabbitescape"

--- a/rabbit-escape-ui-android/build.gradle
+++ b/rabbit-escape-ui-android/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/rabbit-escape-ui-android/gradle/wrapper/gradle-wrapper.properties
+++ b/rabbit-escape-ui-android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip


### PR DESCRIPTION
Without flavorDimensions, builds fail with:

All flavors must now belong to a named flavor dimension.
Learn more at https://d.android.com/r/tools/flavorDimensions-missing-error-message.html